### PR TITLE
Increase numpy version upper bound

### DIFF
--- a/sdmetrics/__init__.py
+++ b/sdmetrics/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = 'MIT Data To AI Lab'
 __email__ = 'dailabmit@gmail.com'
-__version__ = '0.0.2.dev0'
+__version__ = '0.0.2.dev1'
 
 from sdmetrics.evaluation import evaluate
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2.dev0
+current_version = 0.0.2.dev1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<candidate>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,6 @@ setup(
     test_suite='tests',
     tests_require=tests_require,
     url='https://github.com/sdv-dev/SDMetrics',
-    version='0.0.2.dev0',
+    version='0.0.2.dev1',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.md') as history_file:
     history = history_file.read()
 
 install_requires = [
-    'sdv>=0.3.2,<0.3.3',
+    'sdv>=0.3.2,<0.4',
     'rdt>=0.2.1,<0.3',
     'pandas>=0.22.0,<0.25',
     'scikit-learn>=0.20,<1',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'pandas>=0.22.0,<0.25',
     'scikit-learn>=0.20,<1',
     'scipy<1.3,>=0.19.1',
-    'numpy<1.17,>=1.15.4',
+    'numpy<2,>=1.15.4',
     'seaborn>=0.9,<0.11',
     'docutils<0.15,>=0.10',   # prevent incompatibilities
 ]


### PR DESCRIPTION
Increase the numpy version upper bound to increase compatibility with other packages and relax a little bit the SDV version range to support newer versions within the current minor.