### PR TITLE
Dynamic MultiSingleTable metrics

### DIFF
--- a/sdmetrics/single_table/bayesian_network.py
+++ b/sdmetrics/single_table/bayesian_network.py
@@ -1,5 +1,6 @@
 """BayesianNetwork based metrics for single table."""
 
+import json
 import logging
 
 import numpy as np
@@ -46,6 +47,9 @@ class BNLikelihood(SingleTableMetric):
 
         LOGGER.debug('Fitting the BayesianNetwork to the real data')
         if structure:
+            if isinstance(structure, dict):
+                structure = BayesianNetwork.from_json(json.dumps(structure)).structure
+
             bn = BayesianNetwork.from_structure(real_data[fields].to_numpy(), structure)
         else:
             bn = BayesianNetwork.from_samples(real_data[fields].to_numpy(), algorithm='chow-liu')
@@ -71,11 +75,13 @@ class BNLikelihood(SingleTableMetric):
                 The values from the synthetic dataset.
             metadata (dict):
                 Table metadata dict. If not passed, it is build based on the
-                real_data fields and dtypes.
-            structure (tuple[tuple]):
+                real_data fields and dtypes. Optionally, the metadata can include
+                a ``structure`` entry with the structure of the Bayesian Network.
+            structure (dict):
                 Optional. BayesianNetwork structure to use when fitting
                 to the real data. If not passed, learn it from the data
-                using the ``chow-liu`` algorith.
+                using the ``chow-liu`` algorith. This is ignored if ``metadata``
+                is passed and it contains a ``structure`` entry in it.
 
         Returns:
             float:
@@ -119,11 +125,13 @@ class BNLogLikelihood(BNLikelihood):
                 The values from the synthetic dataset.
             metadata (dict):
                 Table metadata dict. If not passed, it is build based on the
-                real_data fields and dtypes.
-            structure (tuple[tuple]):
+                real_data fields and dtypes. Optionally, the metadata can include
+                a ``structure`` entry with the structure of the Bayesian Network.
+            structure (dict):
                 Optional. BayesianNetwork structure to use when fitting
                 to the real data. If not passed, learn it from the data
-                using the ``chow-liu`` algorith.
+                using the ``chow-liu`` algorith. This is ignored if ``metadata``
+                is passed and it contains a ``structure`` entry in it.
 
         Returns:
             float:

--- a/sdmetrics/single_table/detection/base.py
+++ b/sdmetrics/single_table/detection/base.py
@@ -62,7 +62,8 @@ class DetectionMetric(SingleTableMetric):
 
         X = np.concatenate([real_data, synthetic_data])
         y = np.hstack([np.ones(len(real_data)), np.zeros(len(synthetic_data))])
-        X[np.isin(X, [np.inf, -np.inf])] = None
+        if np.isin(X, [np.inf, -np.inf]).any():
+            X[np.isin(X, [np.inf, -np.inf])] = np.nan
 
         scores = []
         kf = StratifiedKFold(n_splits=3, shuffle=True)

--- a/sdmetrics/single_table/detection/sklearn.py
+++ b/sdmetrics/single_table/detection/sklearn.py
@@ -28,7 +28,6 @@ class ScikitLearnClassifierDetectionMetric(DetectionMetric):
     @classmethod
     def fit_predict(cls, X_train, y_train, X_test):
         """Fit a pipeline to train data and then use it to make prediction on test data."""
-        X_train[np.isin(X_train, [np.inf, -np.inf])] = None
         model = Pipeline([
             ('imputer', SimpleImputer()),
             ('scalar', RobustScaler()),
@@ -36,7 +35,6 @@ class ScikitLearnClassifierDetectionMetric(DetectionMetric):
         ])
         model.fit(X_train, y_train)
 
-        X_test[np.isin(X_test, [np.inf, -np.inf])] = None
         return model.predict_proba(X_test)[:, 1]
 
 

--- a/sdmetrics/single_table/detection/sklearn.py
+++ b/sdmetrics/single_table/detection/sklearn.py
@@ -1,6 +1,5 @@
 """scikit-learn based DetectionMetrics for single table datasets."""
 
-import numpy as np
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import Pipeline


### PR DESCRIPTION
Allow passing a SingleTable metric as an argument to MultiSingleTable metric, so MultiSingleTable metrics can be defined dynamically without the need to create a class.
Also support passing BN structure as both a tuple of tuples or as an entire dict representation of a previous BN instance.