### PR TITLE
Organize Imports and add Generic MLEfficacy and get_subclasses

### DIFF
--- a/sdmetrics/__init__.py
+++ b/sdmetrics/__init__.py
@@ -7,11 +7,12 @@ __email__ = 'dailabmit@gmail.com'
 __version__ = '0.1.0.dev0'
 
 
-from sdmetrics import goal, multi_table, single_column, single_table, timeseries
+from sdmetrics import column_pairs, goal, multi_table, single_column, single_table, timeseries
 
 __all__ = [
     'goal',
     'multi_table',
+    'column_pairs',
     'single_column',
     'single_table',
     'timeseries',

--- a/sdmetrics/base.py
+++ b/sdmetrics/base.py
@@ -20,6 +20,16 @@ class BaseMetric:
     min_value = None
     max_value = None
 
+    @classmethod
+    def get_subclasses(cls):
+        """Recursively find subclasses of this metric."""
+        subclasses = dict()
+        for subclass in cls.__subclasses__():
+            subclasses[subclass.__name__] = subclass
+            subclasses.update(subclass.get_subclasses())
+
+        return subclasses
+
     @staticmethod
     def compute(real_data, synthetic_data):
         """Compute this metric.

--- a/sdmetrics/column_pairs/__init__.py
+++ b/sdmetrics/column_pairs/__init__.py
@@ -1,7 +1,13 @@
 """Metrics to compare column pairs."""
 
 from sdmetrics.column_pairs import statistical
+from sdmetrics.column_pairs.base import ColumnPairsMetric
+from sdmetrics.column_pairs.statistical.kl_divergence import (
+    ContinuousKLDivergence, DiscreteKLDivergence)
 
 __all__ = [
-    'statistical'
+    'statistical',
+    'ColumnPairsMetric',
+    'ContinuousKLDivergence',
+    'DiscreteKLDivergence',
 ]

--- a/sdmetrics/column_pairs/base.py
+++ b/sdmetrics/column_pairs/base.py
@@ -15,15 +15,12 @@ class ColumnPairsMetric(BaseMetric):
             Minimum value or values that this metric can take.
         max_value (Union[float, tuple[float]]):
             Maximum value or values that this metric can take.
-        dtypes (tuple[str]):
-            The data types which this metric works on (i.e. ``('object', 'bool')``).
     """
 
     name = None
     goal = None
     min_value = None
     max_value = None
-    dtypes = ()
 
     @staticmethod
     def compute(real_data, synthetic_data):

--- a/sdmetrics/column_pairs/statistical/__init__.py
+++ b/sdmetrics/column_pairs/statistical/__init__.py
@@ -1,7 +1,9 @@
 """Statistical Metrics to compare column pairs."""
 
-from sdmetrics.column_pairs.statistical import kl_divergence
+from sdmetrics.column_pairs.statistical.kl_divergence import (
+    ContinuousKLDivergence, DiscreteKLDivergence)
 
 __all__ = [
-    'kl_divergence'
+    'ContinuousKLDivergence',
+    'DiscreteKLDivergence',
 ]

--- a/sdmetrics/column_pairs/statistical/kl_divergence.py
+++ b/sdmetrics/column_pairs/statistical/kl_divergence.py
@@ -25,15 +25,12 @@ class ContinuousKLDivergence(ColumnPairsMetric):
             Minimum value or values that this metric can take.
         max_value (Union[float, tuple[float]]):
             Maximum value or values that this metric can take.
-        dtypes (tuple[str]):
-            The data types which this metric works on (i.e. ``('float', 'int')``).
     """
 
     name = 'Continuous Kullback–Leibler Divergence'
     goal = Goal.MAXIMIZE
     min_value = 0.0
     max_value = 1.0
-    dtypes = ('number')
 
     @staticmethod
     def compute(real_data, synthetic_data):
@@ -80,15 +77,12 @@ class DiscreteKLDivergence(ColumnPairsMetric):
             Minimum value or values that this metric can take.
         max_value (Union[float, tuple[float]]):
             Maximum value or values that this metric can take.
-        dtypes (tuple[str]):
-            The data types which this metric works on (i.e. ``('object', 'bool')``).
     """
 
     name = 'Discrete Kullback–Leibler Divergence'
     goal = Goal.MAXIMIZE
     min_value = 0.0
     max_value = 1.0
-    dtypes = ('object', 'bool')
 
     @staticmethod
     def compute(real_data, synthetic_data):

--- a/sdmetrics/multi_table/__init__.py
+++ b/sdmetrics/multi_table/__init__.py
@@ -1,8 +1,28 @@
 """Metrics for multi table datasets."""
 
 from sdmetrics.multi_table import detection, multi_single_table
+from sdmetrics.multi_table.base import MultiTableMetric
+from sdmetrics.multi_table.detection.base import DetectionMetric
+from sdmetrics.multi_table.detection.parent_child import (
+    LogisticParentChildDetection, ParentChildDetectionMetric, SVCParentChildDetection)
+from sdmetrics.multi_table.multi_single_table import (
+    BNLikelihood, BNLogLikelihood, CSTest, KSTest, KSTestExtended, LogisticDetection,
+    MultiSingleTableMetric, SVCDetection)
 
 __all__ = [
     'detection',
     'multi_single_table',
+    'MultiTableMetric',
+    'DetectionMetric',
+    'ParentChildDetectionMetric',
+    'LogisticParentChildDetection',
+    'SVCParentChildDetection',
+    'BNLikelihood',
+    'BNLogLikelihood',
+    'CSTest',
+    'KSTest',
+    'KSTestExtended',
+    'LogisticDetection',
+    'SVCDetection',
+    'MultiSingleTableMetric',
 ]

--- a/sdmetrics/multi_table/multi_single_table.py
+++ b/sdmetrics/multi_table/multi_single_table.py
@@ -40,6 +40,9 @@ class MultiSingleTableMetric(MultiTableMetric, metaclass=NestedAttrsMeta('single
             metadata (dict):
                 Multi-table metadata dict. If not passed, it is build based on the
                 real_data fields and dtypes.
+            **kwargs:
+                Any additional keyword arguments will be passed down
+                to the single table metric
 
         Returns:
             Union[float, tuple[float]]:
@@ -59,7 +62,7 @@ class MultiSingleTableMetric(MultiTableMetric, metaclass=NestedAttrsMeta('single
         return np.nanmean(values)
 
     @classmethod
-    def compute(cls, real_data, synthetic_data, metadata=None):
+    def compute(cls, real_data, synthetic_data, metadata=None, **kwargs):
         """Compute this metric.
 
         Args:
@@ -70,12 +73,15 @@ class MultiSingleTableMetric(MultiTableMetric, metaclass=NestedAttrsMeta('single
             metadata (dict):
                 Multi-table metadata dict. If not passed, it is build based on the
                 real_data fields and dtypes.
+            **kwargs:
+                Any additional keyword arguments will be passed down
+                to the single table metric
 
         Returns:
             Union[float, tuple[float]]:
                 Metric output.
         """
-        return cls._compute(cls, real_data, synthetic_data, metadata)
+        return cls._compute(cls, real_data, synthetic_data, metadata, **kwargs)
 
 
 class CSTest(MultiSingleTableMetric):

--- a/sdmetrics/single_column/__init__.py
+++ b/sdmetrics/single_column/__init__.py
@@ -1,7 +1,14 @@
 """Metrics for Single columns."""
 
-from sdmetrics.single_column import statistical
+from sdmetrics.single_column import base, statistical
+from sdmetrics.single_column.base import SingleColumnMetric
+from sdmetrics.single_column.statistical.cstest import CSTest
+from sdmetrics.single_column.statistical.kstest import KSTest
 
 __all__ = [
-    'statistical'
+    'base',
+    'statistical',
+    'SingleColumnMetric',
+    'CSTest',
+    'KSTest',
 ]

--- a/sdmetrics/single_column/base.py
+++ b/sdmetrics/single_column/base.py
@@ -15,15 +15,12 @@ class SingleColumnMetric(BaseMetric):
             Minimum value or values that this metric can take.
         max_value (Union[float, tuple[float]]):
             Maximum value or values that this metric can take.
-        dtypes (tuple[str]):
-            The data types which this metric works on (i.e. ``('float', 'str')``).
     """
 
     name = None
     goal = None
     min_value = None
     max_value = None
-    dtypes = ()
 
     @staticmethod
     def compute(real_data, synthetic_data):

--- a/sdmetrics/single_table/__init__.py
+++ b/sdmetrics/single_table/__init__.py
@@ -1,12 +1,58 @@
 """Metrics for single table datasets."""
 
 from sdmetrics.single_table import (
-    bayesian_network, detection, efficacy, gaussian_mixture, multi_single_column)
+    base, bayesian_network, detection, efficacy, gaussian_mixture, multi_single_column)
+from sdmetrics.single_table.base import SingleTableMetric
+from sdmetrics.single_table.bayesian_network import BNLikelihood, BNLogLikelihood
+from sdmetrics.single_table.detection.base import DetectionMetric
+from sdmetrics.single_table.detection.sklearn import (
+    LogisticDetection, ScikitLearnClassifierDetectionMetric, SVCDetection)
+from sdmetrics.single_table.efficacy.base import MLEfficacyMetric
+from sdmetrics.single_table.efficacy.binary import (
+    BinaryAdaBoostClassifier, BinaryDecisionTreeClassifier, BinaryEfficacyMetric,
+    BinaryLogisticRegression, BinaryMLPClassifier)
+from sdmetrics.single_table.efficacy.multiclass import (
+    MulticlassDecisionTreeClassifier, MulticlassEfficacyMetric, MulticlassMLPClassifier)
+from sdmetrics.single_table.efficacy.regression import (
+    LinearRegression, MLPRegressor, RegressionEfficacyMetric)
+from sdmetrics.single_table.gaussian_mixture import GMLogLikelihood
+from sdmetrics.single_table.multi_column_pairs import (
+    ContinuousKLDivergence, DiscreteKLDivergence, MultiColumnPairsMetric)
+from sdmetrics.single_table.multi_single_column import (
+    CSTest, KSTest, KSTestExtended, MultiSingleColumnMetric)
 
 __all__ = [
     'bayesian_network',
+    'base',
     'detection',
     'efficacy',
     'gaussian_mixture',
     'multi_single_column',
+    'SingleTableMetric',
+    'BNLikelihood',
+    'BNLogLikelihood',
+    'DetectionMetric',
+    'LogisticDetection',
+    'SVCDetection',
+    'ScikitLearnClassifierDetectionMetric',
+    'MLEfficacyMetric',
+    'BinaryEfficacyMetric',
+    'BinaryDecisionTreeClassifier',
+    'BinaryAdaBoostClassifier',
+    'BinaryLogisticRegression',
+    'BinaryMLPClassifier',
+    'MulticlassEfficacyMetric',
+    'MulticlassDecisionTreeClassifier',
+    'MulticlassMLPClassifier',
+    'RegressionEfficacyMetric',
+    'LinearRegression',
+    'MLPRegressor',
+    'GMLogLikelihood',
+    'MultiColumnPairsMetric',
+    'ContinuousKLDivergence',
+    'DiscreteKLDivergence',
+    'MultiSingleColumnMetric',
+    'CSTest',
+    'KSTest',
+    'KSTestExtended',
 ]

--- a/sdmetrics/single_table/efficacy/__init__.py
+++ b/sdmetrics/single_table/efficacy/__init__.py
@@ -1,8 +1,27 @@
-from sdmetrics.single_table.efficacy import (
-    binary_classification, multiclass_classification, regression)
+from sdmetrics.single_table.efficacy import binary, multiclass, regression
+from sdmetrics.single_table.efficacy.base import MLEfficacyMetric
+from sdmetrics.single_table.efficacy.binary import (
+    BinaryAdaBoostClassifier, BinaryDecisionTreeClassifier, BinaryEfficacyMetric,
+    BinaryLogisticRegression, BinaryMLPClassifier)
+from sdmetrics.single_table.efficacy.multiclass import (
+    MulticlassDecisionTreeClassifier, MulticlassEfficacyMetric, MulticlassMLPClassifier)
+from sdmetrics.single_table.efficacy.regression import (
+    LinearRegression, MLPRegressor, RegressionEfficacyMetric)
 
 __all__ = [
-    'binary_classification',
-    'multiclass_classification',
+    'binary',
+    'multiclass',
     'regression',
+    'MLEfficacyMetric',
+    'BinaryEfficacyMetric',
+    'BinaryDecisionTreeClassifier',
+    'BinaryAdaBoostClassifier',
+    'BinaryLogisticRegression',
+    'BinaryMLPClassifier',
+    'MulticlassEfficacyMetric',
+    'MulticlassDecisionTreeClassifier',
+    'MulticlassMLPClassifier',
+    'RegressionEfficacyMetric',
+    'LinearRegression',
+    'MLPRegressor'
 ]

--- a/sdmetrics/single_table/efficacy/binary.py
+++ b/sdmetrics/single_table/efficacy/binary.py
@@ -10,7 +10,7 @@ from sdmetrics.goal import Goal
 from sdmetrics.single_table.efficacy.base import MLEfficacyMetric
 
 
-class BinaryClassificationEfficacyMetric(MLEfficacyMetric):
+class BinaryEfficacyMetric(MLEfficacyMetric):
     """Base class for Binary Classification Efficacy metrics."""
 
     name = None
@@ -20,7 +20,7 @@ class BinaryClassificationEfficacyMetric(MLEfficacyMetric):
     SCORER = f1_score
 
 
-class BinaryDecisionTreeClassifier(BinaryClassificationEfficacyMetric):
+class BinaryDecisionTreeClassifier(BinaryEfficacyMetric):
 
     MODEL = DecisionTreeClassifier
     MODEL_KWARGS = {
@@ -29,12 +29,12 @@ class BinaryDecisionTreeClassifier(BinaryClassificationEfficacyMetric):
     }
 
 
-class BinaryAdaBoostClassifier(BinaryClassificationEfficacyMetric):
+class BinaryAdaBoostClassifier(BinaryEfficacyMetric):
 
     MODEL = AdaBoostClassifier
 
 
-class BinaryLogisticRegression(BinaryClassificationEfficacyMetric):
+class BinaryLogisticRegression(BinaryEfficacyMetric):
 
     MODEL = LogisticRegression
     MODEL_KWARGS = {
@@ -45,7 +45,7 @@ class BinaryLogisticRegression(BinaryClassificationEfficacyMetric):
     }
 
 
-class BinaryMLPClassifier(BinaryClassificationEfficacyMetric):
+class BinaryMLPClassifier(BinaryEfficacyMetric):
 
     MODEL = MLPClassifier
     MODEL_KWARGS = {

--- a/sdmetrics/single_table/efficacy/mlefficacy.py
+++ b/sdmetrics/single_table/efficacy/mlefficacy.py
@@ -1,0 +1,77 @@
+import logging
+
+import numpy as np
+
+from sdmetrics.goal import Goal
+from sdmetrics.single_table.efficacy.base import MLEfficacyMetric
+from sdmetrics.single_table.efficacy.binary import BinaryEfficacyMetric
+from sdmetrics.single_table.efficacy.multiclass import MulticlassEfficacyMetric
+from sdmetrics.single_table.efficacy.regression import RegressionEfficacyMetric
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MLEfficacy(MLEfficacyMetric):
+    """Problem and ML Model agnostic efficacy metric.
+
+    This metric analyzes the target column and applies all the Regression, Binary
+    Classification or Multiclass Classification metrics to the table depending
+    on the type of column that needs to be predicted.
+
+    The output is the average score obtained by the different metrics of the
+    chosen type.
+    """
+
+    name = 'Machine Learning Efficacy'
+    goal = Goal.MAXIMIZE
+    min_value = -np.inf
+    max_value = np.inf
+
+    @classmethod
+    def compute(cls, real_data, synthetic_data, metadata=None, target=None):
+        """Compute this metric.
+
+        Args:
+            real_data (Union[numpy.ndarray, pandas.DataFrame]):
+                The values from the real dataset.
+            synthetic_data (Union[numpy.ndarray, pandas.DataFrame]):
+                The values from the synthetic dataset.
+            target (str):
+                Name of the column to use as the target.
+            scorer (Union[callable, list[callable], NoneType]):
+                Scorer (or list of scorers) to apply. If not passed, use the default
+                one for the type of metric.
+
+        Returns:
+            union[float, tuple[float]]:
+                Scores obtained by the models when evaluated on the real data.
+        """
+        target = cls._validate_inputs(real_data, synthetic_data, metadata, target)
+        target_type = metadata['fields'][target]['type']
+        target_data = real_data[target]
+        uniques = target_data.unique()
+        if len(uniques) == 2:
+            LOGGER.info('MLEfficacy: Selecting Binary Classification metrics')
+            if target_data.dtype == 'object':
+                first_label = target_data.unique()[0]
+                real_data = real_data.copy()
+                synthetic_data = synthetic_data.copy()
+                real_data[target] = target_data == first_label
+                synthetic_data[target] = synthetic_data[target] == first_label
+
+            metrics = BinaryEfficacyMetric.get_subclasses()
+        elif target_type == 'numerical':
+            LOGGER.info('MLEfficacy: Selecting Regression metrics')
+            metrics = RegressionEfficacyMetric.get_subclasses()
+        elif target_type == 'categorical':
+            LOGGER.info('MLEfficacy: Selecting Multiclass Classification metrics')
+            metrics = MulticlassEfficacyMetric.get_subclasses()
+        else:
+            raise ValueError(f'Unsupported target type: {target_type}')
+
+        scores = []
+        for name, metric in metrics.items():
+            LOGGER.info('MLEfficacy: Computing %s', name)
+            scores.append(metric.compute(real_data, synthetic_data, metadata, target))
+
+        return np.nanmean(scores)

--- a/sdmetrics/single_table/efficacy/multiclass.py
+++ b/sdmetrics/single_table/efficacy/multiclass.py
@@ -12,7 +12,7 @@ def f1_macro(real_target, predictions):
     return f1_score(real_target, predictions, average='macro'),
 
 
-class MulticlassClassificationEfficacyMetric(MLEfficacyMetric):
+class MulticlassEfficacyMetric(MLEfficacyMetric):
     """Base class for Multiclass Classification Efficacy Metrics."""
 
     name = None
@@ -22,7 +22,7 @@ class MulticlassClassificationEfficacyMetric(MLEfficacyMetric):
     SCORER = f1_macro
 
 
-class MulticlassDecisionTreeClassifier(MulticlassClassificationEfficacyMetric):
+class MulticlassDecisionTreeClassifier(MulticlassEfficacyMetric):
 
     MODEL = DecisionTreeClassifier
     MODEL_KWARGS = {
@@ -31,7 +31,7 @@ class MulticlassDecisionTreeClassifier(MulticlassClassificationEfficacyMetric):
     }
 
 
-class MulticlassMLPClassifier(MulticlassClassificationEfficacyMetric):
+class MulticlassMLPClassifier(MulticlassEfficacyMetric):
 
     MODEL = MLPClassifier
     MODEL_KWARGS = {

--- a/tests/integration/single_table/efficacy/test_binary.py
+++ b/tests/integration/single_table/efficacy/test_binary.py
@@ -2,16 +2,18 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sdmetrics.single_table.efficacy.multiclass_classification import (
-    MulticlassDecisionTreeClassifier, MulticlassMLPClassifier)
+from sdmetrics.single_table.efficacy.binary import (
+    BinaryAdaBoostClassifier, BinaryDecisionTreeClassifier, BinaryLogisticRegression,
+    BinaryMLPClassifier)
 
 METRICS = [
-    MulticlassDecisionTreeClassifier,
-    MulticlassMLPClassifier,
+    BinaryAdaBoostClassifier,
+    BinaryDecisionTreeClassifier,
+    BinaryLogisticRegression,
+    BinaryMLPClassifier
 ]
 
 
-@pytest.fixture
 def real_data():
     return pd.DataFrame({
         'a': np.random.normal(size=600),
@@ -21,7 +23,6 @@ def real_data():
     })
 
 
-@pytest.fixture
 def good_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=0.01, size=600),
@@ -31,7 +32,6 @@ def good_data():
     })
 
 
-@pytest.fixture
 def bad_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=5, scale=3, size=600),
@@ -42,9 +42,9 @@ def bad_data():
 
 
 @pytest.mark.parametrize('metric', METRICS)
-def test_rank(metric, real_data, good_data, bad_data):
-    bad = metric.compute(real_data, bad_data, target='c')
-    good = metric.compute(real_data, good_data, target='c')
-    real = metric.compute(real_data, real_data, target='c')
+def test_rank(metric):
+    bad = metric.compute(real_data(), bad_data(), target='d')
+    good = metric.compute(real_data(), good_data(), target='d')
+    real = metric.compute(real_data(), real_data(), target='d')
 
-    assert metric.min_value <= bad < good < real <= metric.max_value
+    assert metric.min_value <= bad < good <= real <= metric.max_value

--- a/tests/integration/single_table/efficacy/test_multiclass.py
+++ b/tests/integration/single_table/efficacy/test_multiclass.py
@@ -2,18 +2,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sdmetrics.single_table.efficacy.binary_classification import (
-    BinaryAdaBoostClassifier, BinaryDecisionTreeClassifier, BinaryLogisticRegression,
-    BinaryMLPClassifier)
+from sdmetrics.single_table.efficacy.multiclass import (
+    MulticlassDecisionTreeClassifier, MulticlassMLPClassifier)
 
 METRICS = [
-    BinaryAdaBoostClassifier,
-    BinaryDecisionTreeClassifier,
-    BinaryLogisticRegression,
-    BinaryMLPClassifier
+    MulticlassDecisionTreeClassifier,
+    MulticlassMLPClassifier,
 ]
 
 
+@pytest.fixture
 def real_data():
     return pd.DataFrame({
         'a': np.random.normal(size=600),
@@ -23,6 +21,7 @@ def real_data():
     })
 
 
+@pytest.fixture
 def good_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=0.01, size=600),
@@ -32,6 +31,7 @@ def good_data():
     })
 
 
+@pytest.fixture
 def bad_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=5, scale=3, size=600),
@@ -42,9 +42,9 @@ def bad_data():
 
 
 @pytest.mark.parametrize('metric', METRICS)
-def test_rank(metric):
-    bad = metric.compute(real_data(), bad_data(), target='d')
-    good = metric.compute(real_data(), good_data(), target='d')
-    real = metric.compute(real_data(), real_data(), target='d')
+def test_rank(metric, real_data, good_data, bad_data):
+    bad = metric.compute(real_data, bad_data, target='c')
+    good = metric.compute(real_data, good_data, target='c')
+    real = metric.compute(real_data, real_data, target='c')
 
-    assert metric.min_value <= bad < good <= real <= metric.max_value
+    assert metric.min_value <= bad < good < real <= metric.max_value

--- a/tests/integration/single_table/test_single_table.py
+++ b/tests/integration/single_table/test_single_table.py
@@ -25,50 +25,50 @@ METRICS = [
 @pytest.fixture
 def ones():
     return pd.DataFrame({
-        'a': [1] * 100,
-        'b': [True] * 100,
-        'c': [1.0] * 100,
-        'd': [True] * 100,
+        'a': [1] * 300,
+        'b': [True] * 300,
+        'c': [1.0] * 300,
+        'd': [True] * 300,
     })
 
 
 @pytest.fixture
 def zeros():
     return pd.DataFrame({
-        'a': [0] * 100,
-        'b': [False] * 100,
-        'c': [0.0] * 100,
-        'd': [False] * 100,
+        'a': [0] * 300,
+        'b': [False] * 300,
+        'c': [0.0] * 300,
+        'd': [False] * 300,
     })
 
 
 @pytest.fixture
 def real_data():
     return pd.DataFrame({
-        'a': np.random.normal(size=600),
-        'b': np.random.randint(0, 10, size=600),
-        'c': ['a', 'b', 'b', 'c', 'c', 'c'] * 100,
-        'd': [True, True, True, True, True, False] * 100,
+        'a': np.random.normal(size=1800),
+        'b': np.random.randint(0, 10, size=1800),
+        'c': ['a', 'b', 'b', 'c', 'c', 'c'] * 300,
+        'd': [True, True, True, True, True, False] * 300,
     })
 
 
 @pytest.fixture
 def good_data():
     return pd.DataFrame({
-        'a': np.random.normal(loc=0.01, size=600),
-        'b': np.random.randint(0, 10, size=600),
-        'c': ['a', 'b', 'b', 'b', 'c', 'c'] * 100,
-        'd': [True, True, True, True, False, False] * 100,
+        'a': np.random.normal(loc=0.01, size=1800),
+        'b': np.random.randint(0, 10, size=1800),
+        'c': ['a', 'b', 'b', 'b', 'c', 'c'] * 300,
+        'd': [True, True, True, True, False, False] * 300,
     })
 
 
 @pytest.fixture
 def bad_data():
     return pd.DataFrame({
-        'a': np.random.normal(loc=5, scale=3, size=600),
-        'b': np.random.randint(5, 15, size=600),
-        'c': ['a', 'a', 'a', 'a', 'b', 'b'] * 100,
-        'd': [True, False, False, False, False, False] * 100,
+        'a': np.random.normal(loc=5, scale=3, size=1800),
+        'b': np.random.randint(5, 15, size=1800),
+        'c': ['a', 'a', 'a', 'a', 'b', 'b'] * 300,
+        'd': [True, False, False, False, False, False] * 300,
     })
 
 


### PR DESCRIPTION
* Add imports in all the package `__init__` files to properly expose the public API and rename a few modules and base classes to make imports shorter.
* Add a `get_subclasses`  method to the `BaseMetric` class to easily find subclasses for any type of metric
* Add a generic MLEfficacy metric which selects the type of ML problem to solve based on the target type and then applies all the metrics that exist for that type of problem.
* Add dynamic MultiSingleColumn and MultiColumnPairs metric creation like we already have for MultiSingleTable