### PR TITLE
Allow passing non dict metadata

### DIFF
--- a/sdmetrics/multi_table/detection/parent_child.py
+++ b/sdmetrics/multi_table/detection/parent_child.py
@@ -36,6 +36,9 @@ class ParentChildDetectionMetric(DetectionMetric,
 
     @staticmethod
     def _extract_foreign_keys(metadata):
+        if not isinstance(metadata, dict):
+            metadata = metadata.to_dict()
+
         foreign_keys = []
         for child_table, child_meta in metadata['tables'].items():
             for child_key, field_meta in child_meta['fields'].items():

--- a/sdmetrics/multi_table/multi_single_table.py
+++ b/sdmetrics/multi_table/multi_single_table.py
@@ -1,5 +1,7 @@
 """MultiTable metrics based on applying SingleTable metrics on all the tables."""
 
+from collections import defaultdict
+
 import numpy as np
 
 from sdmetrics import single_table
@@ -51,10 +53,15 @@ class MultiSingleTableMetric(MultiTableMetric, metaclass=NestedAttrsMeta('single
         if set(real_data.keys()) != set(synthetic_data.keys()):
             raise ValueError('`real_data` and `synthetic_data` must have the same tables')
 
+        if metadata is None:
+            metadata = {'tables': defaultdict(type(None))}
+        elif not isinstance(metadata, dict):
+            metadata = metadata.to_dict()
+
         values = []
         for table_name, real_table in real_data.items():
             synthetic_table = synthetic_data[table_name]
-            table_meta = metadata['tables'][table_name] if metadata else None
+            table_meta = metadata['tables'][table_name]
 
             score = self.single_table_metric.compute(real_table, synthetic_table, table_meta)
             values.append(score)

--- a/sdmetrics/single_table/base.py
+++ b/sdmetrics/single_table/base.py
@@ -64,6 +64,9 @@ class SingleTableMetric(BaseMetric):
             raise ValueError('`real_data` and `synthetic_data` must have the same columns')
 
         if metadata is not None:
+            if not isinstance(metadata, dict):
+                metadata = metadata.to_dict()
+
             fields = metadata['fields']
             for column in real_data.columns:
                 if column not in fields:


### PR DESCRIPTION
Support passing a metadata that is not a `dict` but has a `to_dict` method. This allows passing `Metadata` and `Table` objects directly.