### PR TITLE
Ensure binary classification targets are bool

### DIFF
--- a/sdmetrics/single_table/efficacy/binary.py
+++ b/sdmetrics/single_table/efficacy/binary.py
@@ -19,6 +19,23 @@ class BinaryEfficacyMetric(MLEfficacyMetric):
     max_value = 1
     SCORER = f1_score
 
+    @classmethod
+    def _score(cls, scorer, real_target, predictions):
+        if real_target.dtype == 'object':
+            first_label = real_target.unique()[0]
+            real_target = real_target == first_label
+            if predictions.dtype == 'object':
+                predictions = predictions == first_label
+
+        return super()._score(scorer, real_target, predictions)
+
+    @classmethod
+    def _fit_predict(cls, synthetic_data, synthetic_target, real_data, real_target):
+        if real_target.dtype == 'object':
+            synthetic_target = synthetic_target == real_target.unique()[0]
+
+        return super()._fit_predict(synthetic_data, synthetic_target, real_data, real_target)
+
 
 class BinaryDecisionTreeClassifier(BinaryEfficacyMetric):
     """Binary DecisionTreeClassifier Efficacy based metric.

--- a/sdmetrics/single_table/efficacy/mlefficacy.py
+++ b/sdmetrics/single_table/efficacy/mlefficacy.py
@@ -63,13 +63,6 @@ class MLEfficacy(MLEfficacyMetric):
         uniques = target_data.unique()
         if len(uniques) == 2:
             LOGGER.info('MLEfficacy: Selecting Binary Classification metrics')
-            if target_data.dtype == 'object':
-                first_label = target_data.unique()[0]
-                real_data = real_data.copy()
-                synthetic_data = synthetic_data.copy()
-                real_data[target] = target_data == first_label
-                synthetic_data[target] = synthetic_data[target] == first_label
-
             metrics = BinaryEfficacyMetric.get_subclasses()
         elif target_type == 'numerical':
             LOGGER.info('MLEfficacy: Selecting Regression metrics')

--- a/tests/integration/single_table/efficacy/test_binary.py
+++ b/tests/integration/single_table/efficacy/test_binary.py
@@ -14,31 +14,43 @@ METRICS = [
 ]
 
 
-def real_data():
-    return pd.DataFrame({
+def real_data(as_str=False):
+    data = pd.DataFrame({
         'a': np.random.normal(size=600),
         'b': np.random.randint(0, 10, size=600),
         'c': ['a', 'b', 'b', 'c', 'c', 'c'] * 100,
         'd': [True, True, True, True, True, False] * 100,
     })
+    if as_str:
+        data['d'] = data['d'].astype(str)
+
+    return data
 
 
-def good_data():
-    return pd.DataFrame({
+def good_data(as_str=False):
+    data = pd.DataFrame({
         'a': np.random.normal(loc=0.01, size=600),
         'b': np.random.randint(0, 10, size=600),
         'c': ['a', 'b', 'b', 'b', 'c', 'c'] * 100,
         'd': [True, True, True, True, False, False] * 100,
     })
+    if as_str:
+        data['d'] = data['d'].astype(str)
+
+    return data
 
 
-def bad_data():
-    return pd.DataFrame({
+def bad_data(as_str=False):
+    data = pd.DataFrame({
         'a': np.random.normal(loc=5, scale=3, size=600),
         'b': np.random.randint(5, 15, size=600),
         'c': ['a', 'a', 'a', 'a', 'b', 'b'] * 100,
         'd': [True, False, False, False, False, False] * 100,
     })
+    if as_str:
+        data['d'] = data['d'].astype(str)
+
+    return data
 
 
 @pytest.mark.parametrize('metric', METRICS)
@@ -46,5 +58,14 @@ def test_rank(metric):
     bad = metric.compute(real_data(), bad_data(), target='d')
     good = metric.compute(real_data(), good_data(), target='d')
     real = metric.compute(real_data(), real_data(), target='d')
+
+    assert metric.min_value <= bad < good <= real <= metric.max_value
+
+
+@pytest.mark.parametrize('metric', METRICS)
+def test_rank_object(metric):
+    bad = metric.compute(real_data(True), bad_data(True), target='d')
+    good = metric.compute(real_data(True), good_data(True), target='d')
+    real = metric.compute(real_data(True), real_data(True), target='d')
 
     assert metric.min_value <= bad < good <= real <= metric.max_value

--- a/tests/integration/single_table/efficacy/test_multiclass.py
+++ b/tests/integration/single_table/efficacy/test_multiclass.py
@@ -14,18 +14,18 @@ METRICS = [
 @pytest.fixture
 def real_data():
     return pd.DataFrame({
-        'a': np.random.normal(size=600),
-        'b': np.random.randint(0, 10, size=600),
-        'c': ['a', 'b', 'b', 'c', 'c', 'c'] * 100,
-        'd': [True, True, True, True, True, False] * 100,
+        'a': np.random.normal(size=6000),
+        'b': np.random.randint(0, 10, size=6000),
+        'c': ['a', 'b', 'b', 'c', 'c', 'c'] * 1000,
+        'd': [True, True, True, True, True, False] * 1000,
     })
 
 
 @pytest.fixture
 def good_data():
     return pd.DataFrame({
-        'a': np.random.normal(loc=0.01, size=600),
-        'b': np.random.randint(0, 10, size=600),
+        'a': np.random.normal(loc=5, size=600),
+        'b': np.random.randint(5, 15, size=600),
         'c': ['a', 'b', 'b', 'b', 'c', 'c'] * 100,
         'd': [True, True, True, True, False, False] * 100,
     })
@@ -34,9 +34,9 @@ def good_data():
 @pytest.fixture
 def bad_data():
     return pd.DataFrame({
-        'a': np.random.normal(loc=5, scale=3, size=600),
-        'b': np.random.randint(5, 15, size=600),
-        'c': ['a', 'a', 'a', 'a', 'b', 'b'] * 100,
+        'a': np.random.normal(loc=10, scale=3, size=600),
+        'b': np.random.randint(10, 20, size=600),
+        'c': ['a', 'a', 'a', 'a', 'a', 'b'] * 100,
         'd': [True, False, False, False, False, False] * 100,
     })
 
@@ -47,4 +47,7 @@ def test_rank(metric, real_data, good_data, bad_data):
     good = metric.compute(real_data, good_data, target='c')
     real = metric.compute(real_data, real_data, target='c')
 
-    assert metric.min_value <= bad < good < real <= metric.max_value
+    assert metric.min_value <= bad
+    assert bad < good
+    assert good < real
+    assert real <= metric.max_value


### PR DESCRIPTION
When a binary classification dataset which has a target column that is not boolean (so, instead of containing `True/False` or `0/1` it contains 2 possible categories represented by strings or numerical values other than 0 and 1), the BinaryClassification metrics fail to get a score.

This PR adds a preprocessing step that detects this situation and re-encodes the binary categorical target variable as a boolean array.