### PR TITLE
Fixes the sktime issue for conda

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,10 +20,10 @@ requirements:
     - pytest-runner
     - scikit-learn >=0.20,<1
     - scipy >=1.1.0,<1.6.0
-    - numpy >=1.15.4,<2
+    - numpy >=1.15.0,<2
     - pandas >=1,<1.1.5
-    - seaborn >=0.9,<0.11
-    - matplotlib >=2.2.2,<3.2.2
+    - seaborn
+    - matplotlib
     - pomegranate >=0.13.0,<0.13.5
     - rdt >=0.2.10,<0.4
     - pytorch >=1,<2
@@ -32,10 +32,10 @@ requirements:
     - python
     - scikit-learn >=0.20,<1
     - scipy >=1.1.0,<1.6.0
-    - numpy >=1.15.4,<2
+    - numpy >=1.15.0,<2
     - pandas >=1,<1.1.5
-    - seaborn >=0.9,<0.11
-    - matplotlib >=2.2.2,<3.2.2
+    - seaborn
+    - matplotlib
     - pomegranate >=0.13.0,<0.13.5
     - rdt >=0.2.10,<0.4
     - pytorch >=1,<2

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'sdmetrics' %}
-{% set version = '0.1.2' %}
+{% set version = '0.1.3.dev0' %}
 
 package:
   name: "{{ name|lower }}"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'sdmetrics' %}
-{% set version = '0.1.3.dev0' %}
+{% set version = '0.1.2' %}
 
 package:
   name: "{{ name|lower }}"
@@ -20,29 +20,23 @@ requirements:
     - pytest-runner
     - scikit-learn >=0.20,<1
     - scipy >=1.1.0,<1.6.0
-    - numpy >=1.15.0,<2
+    - numpy >=1.15.4,<2
     - pandas >=1,<1.1.5
-    - seaborn
-    - matplotlib
     - pomegranate >=0.13.0,<0.13.5
     - rdt >=0.2.10,<0.4
     - pytorch >=1,<2
     - sktime >=0.5,<0.6
-    - tsfresh >=0.15,<1
 
   run:
     - python
     - scikit-learn >=0.20,<1
     - scipy >=1.1.0,<1.6.0
-    - numpy >=1.15.0,<2
+    - numpy >=1.15.4,<2
     - pandas >=1,<1.1.5
-    - seaborn
-    - matplotlib
     - pomegranate >=0.13.0,<0.13.5
     - rdt >=0.2.10,<0.4
     - pytorch >=1,<2
     - sktime >=0.5,<0.6
-    - tsfresh >=0.15,<1
 
 about:
   home: "https://github.com/sdv-dev/SDMetrics"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - pomegranate >=0.13.0,<0.13.5
     - rdt >=0.2.10,<0.4
     - pytorch >=1,<2
+    - sktime >=0.5,<0.6
+    - tsfresh >=0.15,<1
 
   run:
     - python
@@ -39,6 +41,8 @@ requirements:
     - pomegranate >=0.13.0,<0.13.5
     - rdt >=0.2.10,<0.4
     - pytorch >=1,<2
+    - sktime >=0.5,<0.6
+    - tsfresh >=0.15,<1
 
 about:
   home: "https://github.com/sdv-dev/SDMetrics"

--- a/sdmetrics/timeseries/ml_scorers.py
+++ b/sdmetrics/timeseries/ml_scorers.py
@@ -4,7 +4,11 @@ import rdt
 import torch
 from sklearn.pipeline import Pipeline
 from sktime.classification.compose import TimeSeriesForestClassifier
-from sktime.transformations.panel.compose import ColumnConcatenator
+
+try:
+    from sktime.transformers.series_as_features.compose import ColumnConcatenator
+except (ImportError, AttributeError):
+    from sktime.transformations.panel.compose import ColumnConcatenator
 
 
 def tsf_classifier(X_train, X_test, y_train, y_test):

--- a/sdmetrics/timeseries/ml_scorers.py
+++ b/sdmetrics/timeseries/ml_scorers.py
@@ -4,7 +4,7 @@ import rdt
 import torch
 from sklearn.pipeline import Pipeline
 from sktime.classification.compose import TimeSeriesForestClassifier
-from sktime.transformers.series_as_features.compose import ColumnConcatenator
+from sktime.transformations.panel.compose import ColumnConcatenator
 
 
 def tsf_classifier(X_train, X_test, y_train, y_test):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
 
 install_requires = [
     'scikit-learn>=0.20,<1',
-    'sktime>=0.5,<0.6',
+    'sktime>=0.4,<0.6',
     'tsfresh>=0.15,<1',
     'scipy>=1.1.0,<1.6.0',
     'numpy>=1.15.0,<2',

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
 
 install_requires = [
     'scikit-learn>=0.20,<1',
-    'sktime>=0.4,<0.5',
+    'sktime>=0.5,<0.6',
     'tsfresh>=0.15,<1',
     'scipy>=1.1.0,<1.6.0',
-    'numpy>=1.15.4,<2',
+    'numpy>=1.15.0,<2',
     'pandas>=1,<1.1.5',
     'seaborn>=0.9,<0.11',
     'matplotlib>=2.2.2,<3.2.2',

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,13 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
     history = history_file.read()
 
 install_requires = [
-    'scikit-learn>=0.20,<1',
-    'sktime>=0.4,<0.6',
-    'tsfresh>=0.15,<1',
-    'scipy>=1.1.0,<1.6.0',
-    'numpy>=1.15.0,<2',
+    'numpy>=1.15.4,<2',
     'pandas>=1,<1.1.5',
-    'seaborn>=0.9,<0.11',
-    'matplotlib>=2.2.2,<3.2.2',
     'pomegranate>=0.13.0,<0.13.5',
     'rdt>=0.2.10,<0.4',
+    'scikit-learn>=0.20,<1',
+    'scipy>=1.1.0,<1.6.0',
+    'sktime>=0.4,<0.6',
     'torch>=1,<2',
 ]
 


### PR DESCRIPTION
Updates the dependency requirements in meta.yaml to be able to use the latest versions of sktime, since only v0.5.0 and higher are available in conda-forge. It also makes a small change in the code, since sktime v0.5.0 introduces a breaking API update.