### PR TITLE
Expose missing metrics on the subpackage roots API

### DIFF
--- a/sdmetrics/single_table/__init__.py
+++ b/sdmetrics/single_table/__init__.py
@@ -20,10 +20,15 @@ from sdmetrics.single_table.multi_column_pairs import (
     ContinuousKLDivergence, DiscreteKLDivergence, MultiColumnPairsMetric)
 from sdmetrics.single_table.multi_single_column import (
     CSTest, KSTest, KSTestExtended, MultiSingleColumnMetric)
-from sdmetrics.single_table.privacy import (
-    CategoricalCAP, CategoricalEnsemble, CategoricalGeneralizedCAP, CategoricalKNN, CategoricalNB,
-    CategoricalPrivacyMetric, CategoricalRF, CategoricalZeroCAP, NumericalLR, NumericalMLP,
-    NumericalPrivacyMetric, NumericalRadiusNearestNeighbor, NumericalSVR)
+from sdmetrics.single_table.privacy.base import CategoricalPrivacyMetric, NumericalPrivacyMetric
+from sdmetrics.single_table.privacy.cap import (
+    CategoricalCAP, CategoricalGeneralizedCAP, CategoricalZeroCAP)
+from sdmetrics.single_table.privacy.categorical_sklearn import (
+    CategoricalKNN, CategoricalNB, CategoricalRF, CategoricalSVM)
+from sdmetrics.single_table.privacy.ensemble import CategoricalEnsemble
+from sdmetrics.single_table.privacy.numerical_sklearn import (
+    NumericalLR, NumericalMLP, NumericalSVR)
+from sdmetrics.single_table.privacy.radius_nearest_neighbor import NumericalRadiusNearestNeighbor
 
 __all__ = [
     'bayesian_network',
@@ -69,6 +74,7 @@ __all__ = [
     'CategoricalKNN',
     'CategoricalNB',
     'CategoricalRF',
+    'CategoricalSVM',
     'CategoricalPrivacyMetric',
     'NumericalPrivacyMetric',
     'CategoricalEnsemble',

--- a/sdmetrics/single_table/privacy/__init__.py
+++ b/sdmetrics/single_table/privacy/__init__.py
@@ -2,7 +2,7 @@ from sdmetrics.single_table.privacy.base import CategoricalPrivacyMetric, Numeri
 from sdmetrics.single_table.privacy.cap import (
     CategoricalCAP, CategoricalGeneralizedCAP, CategoricalZeroCAP)
 from sdmetrics.single_table.privacy.categorical_sklearn import (
-    CategoricalKNN, CategoricalNB, CategoricalRF)
+    CategoricalKNN, CategoricalNB, CategoricalRF, CategoricalSVM)
 from sdmetrics.single_table.privacy.ensemble import CategoricalEnsemble
 from sdmetrics.single_table.privacy.numerical_sklearn import (
     NumericalLR, NumericalMLP, NumericalSVR)
@@ -10,16 +10,17 @@ from sdmetrics.single_table.privacy.radius_nearest_neighbor import NumericalRadi
 
 __all__ = [
     'CategoricalCAP',
-    'CategoricalZeroCAP',
+    'CategoricalEnsemble',
     'CategoricalGeneralizedCAP',
-    'NumericalMLP',
-    'NumericalLR',
-    'NumericalSVR',
     'CategoricalKNN',
     'CategoricalNB',
-    'CategoricalRF',
     'CategoricalPrivacyMetric',
+    'CategoricalRF',
+    'CategoricalSVM',
+    'CategoricalZeroCAP',
+    'NumericalLR',
+    'NumericalMLP',
     'NumericalPrivacyMetric',
-    'CategoricalEnsemble',
-    'NumericalRadiusNearestNeighbor'
+    'NumericalRadiusNearestNeighbor',
+    'NumericalSVR',
 ]


### PR DESCRIPTION
Expose the `CategoricalSVM` privacy metric in the `sdmetrics.single_table` and `sdmetrics.single_table.privacy` modules.
Also use explicit imports instead of implicit.