### PR TITLE
Issue 80 add flake8 pytest

### DIFF
--- a/sdmetrics/base.py
+++ b/sdmetrics/base.py
@@ -37,7 +37,7 @@ class BaseMetric:
                 Whether to include subclasses which are parents to
                 other classes. Defaults to ``False``.
         """
-        subclasses = dict()
+        subclasses = {}
         for child in cls.__subclasses__():
             grandchildren = child.get_subclasses(include_parents)
             subclasses.update(grandchildren)

--- a/sdmetrics/single_table/privacy/numerical_sklearn.py
+++ b/sdmetrics/single_table/privacy/numerical_sklearn.py
@@ -17,6 +17,7 @@ class NumericalSklearnAttacker(PrivacyAttackerModel):
         skl_learner (Class):
             A (wrapped) sklearn classifier class that can be called with no arguments.
     """
+
     SKL_LEARNER = None
 
     def __init__(self):

--- a/sdmetrics/single_table/privacy/util.py
+++ b/sdmetrics/single_table/privacy/util.py
@@ -33,7 +33,7 @@ def majority(samples, ignore_none=True):
 
 
 def count_frequency(samples, target):
-    """Calculate how frequent an target attribute appear in a list
+    """Calculate how frequent an target attribute appear in a list.
 
     Arguments:
         samples (list):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,21 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
-extend-ignore = C408, D100, D101, D103, D102, D104, D107, D204, D205, D400, D401, DUO103, VNE001, SFS3, W503
+extend-ignore = DUO103, # insecure use of "pickle" or "cPickle"
+				D100, # Missing docstring in public module
+				D101, # Missing docstring in public class
+				D102, # Missing docstring in public method
+				D103, # Missing docstring in public function
+				D104, # Missing docstring in public package
+				D107, # Missing docstring in __init__
+				D205, # __init__ needs a description
+				D400, # __init__ needs a description
+				D401, # First line should be in imperative mood
+				VNE001, # single letter variable names like 'X' are not allowed
+
+[pydocstyle]
+convention = google
+add-ignore = D107, D407, D417
 
 [isort]
 include_trailing_comment = True
@@ -49,4 +63,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
-ignore = SFS3, W503
+extend-ignore = C408, D100, D101, D103, D102, D104, D107, D204, D205, D400, D401, DUO103, VNE001, SFS3, W503
 
 [isort]
 include_trailing_comment = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
+inline-quotes = single
 extend-ignore = DUO103, # insecure use of "pickle" or "cPickle"
 				D100, # Missing docstring in public module
 				D101, # Missing docstring in public class

--- a/setup.py
+++ b/setup.py
@@ -68,13 +68,9 @@ development_requires = [
     'flake8-eradicate>=1.1.0,<1.2',
     'flake8-mutable>=1.2.0,<1.3',
     'flake8-print>=4.0.0,<4.1',
-    #'flake8-pytest-style>=1.5.0,<2', fkes things up
-    #'pandas-vet>=0.2.2,<0.3', fkes things up
     'flake8-expression-complexity>=0.0.9,<0.1',
     'flake8-multiline-containers>=0.0.18,<0.1',
     'flake8-use-fstring',
-    # 'flake8-quotes>=3.3.0,<4', fkes things up
-    # 'pep8-naming>=0.12.1,<0.13', fkes things up
     'pydocstyle>=6.1.1,<6.2',
 
     # fix style issues

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,25 @@ development_requires = [
     'flake8>=3.7.7,<4',
     'flake8-absolute-import>=1.0,<2',
     'isort>=4.3.4,<5',
+    'flake8-builtins>=1.5.3,<1.6',
+    'flake8-comprehensions>=3.6.1,<3.7',
+    'flake8-debugger>=4.0.0,<4.1',
+    'flake8-docstrings>=1.5.0,<2',
+    'flake8-mock>=0.3,<0.4',
+    'flake8-variables-names>=0.0.4,<0.1',
+    'dlint>=0.11.0,<0.12',  # code security addon for flake8
+    'flake8-fixme>=1.1.1,<1.2',
+    'flake8-eradicate>=1.1.0,<1.2',
+    'flake8-mutable>=1.2.0,<1.3',
+    'flake8-print>=4.0.0,<4.1',
+    #'flake8-pytest-style>=1.5.0,<2', fkes things up
+    #'pandas-vet>=0.2.2,<0.3', fkes things up
+    'flake8-expression-complexity>=0.0.9,<0.1',
+    'flake8-multiline-containers>=0.0.18,<0.1',
+    'flake8-use-fstring',
+    # 'flake8-quotes>=3.3.0,<4', fkes things up
+    # 'pep8-naming>=0.12.1,<0.13', fkes things up
+    'pydocstyle>=6.1.1,<6.2',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,12 @@ development_requires = [
     'flake8-eradicate>=1.1.0,<1.2',
     'flake8-mutable>=1.2.0,<1.3',
     'flake8-print>=4.0.0,<4.1',
+    'flake8-pytest-style>=1.5.0,<2',
     'flake8-expression-complexity>=0.0.9,<0.1',
     'flake8-multiline-containers>=0.0.18,<0.1',
     'flake8-use-fstring',
     'pydocstyle>=6.1.1,<6.2',
+    'pylint>=2.5.3,<3',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/tests/integration/multi_table/test_multi_single_table.py
+++ b/tests/integration/multi_table/test_multi_single_table.py
@@ -8,7 +8,7 @@ from sdmetrics.multi_table.multi_single_table import (
 METRICS = [CSTest, KSTest, LogisticDetection, SVCDetection]
 
 
-@pytest.fixture
+@pytest.fixture()
 def ones():
     data = pd.DataFrame({
         'a': [1] * 100,
@@ -17,7 +17,7 @@ def ones():
     return {'a': data, 'b': data.copy()}
 
 
-@pytest.fixture
+@pytest.fixture()
 def zeros():
     data = pd.DataFrame({
         'a': [0] * 100,
@@ -26,7 +26,7 @@ def zeros():
     return {'a': data, 'b': data.copy()}
 
 
-@pytest.fixture
+@pytest.fixture()
 def real_data():
     data = pd.DataFrame({
         'a': np.random.normal(size=600),
@@ -37,7 +37,7 @@ def real_data():
     return {'a': data, 'b': data.copy()}
 
 
-@pytest.fixture
+@pytest.fixture()
 def good_data():
     data = pd.DataFrame({
         'a': np.random.normal(loc=0.01, size=600),
@@ -48,7 +48,7 @@ def good_data():
     return {'a': data, 'b': data.copy()}
 
 
-@pytest.fixture
+@pytest.fixture()
 def bad_data():
     data = pd.DataFrame({
         'a': np.random.normal(loc=5, scale=3, size=600),
@@ -97,5 +97,6 @@ def test_bad(metric, real_data, bad_data):
 
 @pytest.mark.parametrize('metric', METRICS)
 def test_fail(metric):
-    with pytest.raises(ValueError):
+    error_msg = '`real_data` and `synthetic_data` must have the same tables'
+    with pytest.raises(ValueError, match=error_msg):
         metric.compute({'a': None, 'b': None}, {'a': None})

--- a/tests/integration/single_table/efficacy/test_binary.py
+++ b/tests/integration/single_table/efficacy/test_binary.py
@@ -15,12 +15,12 @@ METRICS = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def real_data():
     return load_breast_cancer(as_frame=True).frame
 
 
-@pytest.fixture
+@pytest.fixture()
 def good_data():
     breast_cancer = load_breast_cancer(as_frame=True)
     data = breast_cancer.data
@@ -34,7 +34,7 @@ def good_data():
     return good
 
 
-@pytest.fixture
+@pytest.fixture()
 def bad_data():
     breast_cancer = load_breast_cancer(as_frame=True)
     data = breast_cancer.data

--- a/tests/integration/single_table/efficacy/test_multiclass.py
+++ b/tests/integration/single_table/efficacy/test_multiclass.py
@@ -12,12 +12,12 @@ METRICS = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def real_data():
     return load_wine(as_frame=True).frame
 
 
-@pytest.fixture
+@pytest.fixture()
 def good_data():
     wine = load_wine(as_frame=True)
     data = wine.data
@@ -31,7 +31,7 @@ def good_data():
     return good
 
 
-@pytest.fixture
+@pytest.fixture()
 def bad_data():
     wine = load_wine(as_frame=True)
     data = wine.data

--- a/tests/integration/single_table/efficacy/test_regression.py
+++ b/tests/integration/single_table/efficacy/test_regression.py
@@ -11,7 +11,7 @@ METRICS = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def real_data():
     boston = load_boston()
     data = pd.DataFrame(boston.data, columns=boston.feature_names)
@@ -19,7 +19,7 @@ def real_data():
     return data
 
 
-@pytest.fixture
+@pytest.fixture()
 def good_data():
     boston = load_boston()
     data = pd.DataFrame(boston.data, columns=boston.feature_names)
@@ -38,7 +38,7 @@ def good_data():
     return good
 
 
-@pytest.fixture
+@pytest.fixture()
 def bad_data():
     boston = load_boston()
     data = pd.DataFrame(boston.data, columns=boston.feature_names)

--- a/tests/integration/single_table/test_gaussian_mixture.py
+++ b/tests/integration/single_table/test_gaussian_mixture.py
@@ -5,7 +5,7 @@ import pytest
 from sdmetrics.single_table.gaussian_mixture import GMLogLikelihood
 
 
-@pytest.fixture
+@pytest.fixture()
 def ones():
     return pd.DataFrame({
         'a': [1] * 300,
@@ -15,7 +15,7 @@ def ones():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def zeros():
     return pd.DataFrame({
         'a': [0] * 300,
@@ -25,7 +25,7 @@ def zeros():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def real_data():
     return pd.DataFrame({
         'a': np.random.normal(size=1800),
@@ -35,7 +35,7 @@ def real_data():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def good_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=0.01, size=1800),
@@ -45,7 +45,7 @@ def good_data():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def bad_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=5, scale=3, size=1800),

--- a/tests/integration/single_table/test_single_table.py
+++ b/tests/integration/single_table/test_single_table.py
@@ -24,7 +24,7 @@ METRICS = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def ones():
     return pd.DataFrame({
         'a': [1] * 300,
@@ -34,7 +34,7 @@ def ones():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def zeros():
     return pd.DataFrame({
         'a': [0] * 300,
@@ -44,7 +44,7 @@ def zeros():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def real_data():
     return pd.DataFrame({
         'a': np.random.normal(size=1800),
@@ -54,7 +54,7 @@ def real_data():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def good_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=0.01, size=1800),
@@ -64,7 +64,7 @@ def good_data():
     })
 
 
-@pytest.fixture
+@pytest.fixture()
 def bad_data():
     return pd.DataFrame({
         'a': np.random.normal(loc=5, scale=3, size=1800),

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -61,6 +61,7 @@ class TestBaseMetric:
         BaseMetric.min_value = -1
         BaseMetric.goal = Goal.MAXIMIZE
 
+        error_msg = '`raw_score` must be between `min_value` and `max_value`.'
         raw_score = 2
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=error_msg):
             BaseMetric.normalize(raw_score)


### PR DESCRIPTION
As part of #80, adds `flake8-pytest-style` and adapt the current code to pass this lint.