### PR TITLE
Add `flake8-docstrings`

### DIFF
--- a/sdmetrics/column_pairs/statistical/kl_divergence.py
+++ b/sdmetrics/column_pairs/statistical/kl_divergence.py
@@ -63,7 +63,7 @@ class ContinuousKLDivergence(ColumnPairsMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):
@@ -109,7 +109,7 @@ class DiscreteKLDivergence(ColumnPairsMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/column_pairs/statistical/kl_divergence.py
+++ b/sdmetrics/column_pairs/statistical/kl_divergence.py
@@ -100,6 +100,18 @@ class DiscreteKLDivergence(ColumnPairsMetric):
 
     @staticmethod
     def compute(real_data, synthetic_data):
+        """Compute the KL divergence.
+
+        Args:
+            real_data:
+                The values from the real dataset.
+            synthetic_data:
+                The values from the synthetic dataset.
+
+        Returns:
+            Union[float, tuple[float]]:
+                Metric output or outputs.
+        """
         columns = real_data.columns[:2]
         real = real_data[columns].itertuples(index=False)
         synthetic = synthetic_data[columns].itertuples(index=False)

--- a/sdmetrics/multi_table/detection/base.py
+++ b/sdmetrics/multi_table/detection/base.py
@@ -48,7 +48,7 @@ class DetectionMetric(MultiTableMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/multi_table/multi_single_table.py
+++ b/sdmetrics/multi_table/multi_single_table.py
@@ -103,7 +103,7 @@ class MultiSingleTableMetric(MultiTableMetric, metaclass=NestedAttrsMeta('single
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_column/statistical/cstest.py
+++ b/sdmetrics/single_column/statistical/cstest.py
@@ -55,7 +55,7 @@ class CSTest(SingleColumnMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_column/statistical/kstest.py
+++ b/sdmetrics/single_column/statistical/kstest.py
@@ -56,7 +56,7 @@ class KSTest(SingleColumnMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_table/detection/base.py
+++ b/sdmetrics/single_table/detection/base.py
@@ -90,7 +90,7 @@ class DetectionMetric(SingleTableMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_table/efficacy/__init__.py
+++ b/sdmetrics/single_table/efficacy/__init__.py
@@ -1,3 +1,5 @@
+"""Single table efficacy metrics module."""
+
 from sdmetrics.single_table.efficacy import binary, multiclass, regression
 from sdmetrics.single_table.efficacy.base import MLEfficacyMetric
 from sdmetrics.single_table.efficacy.binary import (

--- a/sdmetrics/single_table/efficacy/binary.py
+++ b/sdmetrics/single_table/efficacy/binary.py
@@ -38,7 +38,7 @@ class BinaryEfficacyMetric(MLEfficacyMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_table/efficacy/binary.py
+++ b/sdmetrics/single_table/efficacy/binary.py
@@ -1,4 +1,4 @@
-"""Base class for Efficacy metrics for single table datasets."""
+"""Base class for Binary Efficacy metrics for single table datasets."""
 
 from sklearn.ensemble import AdaBoostClassifier
 from sklearn.linear_model import LogisticRegression

--- a/sdmetrics/single_table/efficacy/mlefficacy.py
+++ b/sdmetrics/single_table/efficacy/mlefficacy.py
@@ -80,7 +80,7 @@ class MLEfficacy(MLEfficacyMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns a normalized version of the `raw_score`.
+        """Return a normalized version of the `raw_score`.
 
         This normalizes the raw score by applying the sigmoid function.
 

--- a/sdmetrics/single_table/efficacy/mlefficacy.py
+++ b/sdmetrics/single_table/efficacy/mlefficacy.py
@@ -1,3 +1,5 @@
+"""MLEfficacy metric for single table datasets."""
+
 import logging
 
 import numpy as np

--- a/sdmetrics/single_table/efficacy/multiclass.py
+++ b/sdmetrics/single_table/efficacy/multiclass.py
@@ -1,4 +1,4 @@
-"""Base class for Efficacy metrics for single table datasets."""
+"""Base class for Multiclass Classification Efficacy Metrics for single table datasets."""
 
 from sklearn.metrics import f1_score
 from sklearn.neural_network import MLPClassifier
@@ -9,6 +9,7 @@ from sdmetrics.single_table.efficacy.base import MLEfficacyMetric
 
 
 def f1_macro(real_target, predictions):
+    """Return the `f1_score` of the passed data."""
     return f1_score(real_target, predictions, average='macro')
 
 

--- a/sdmetrics/single_table/efficacy/multiclass.py
+++ b/sdmetrics/single_table/efficacy/multiclass.py
@@ -23,7 +23,7 @@ class MulticlassEfficacyMetric(MLEfficacyMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_table/efficacy/regression.py
+++ b/sdmetrics/single_table/efficacy/regression.py
@@ -19,7 +19,7 @@ class RegressionEfficacyMetric(MLEfficacyMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns a normalized version of the R^2 score.
+        """Return a normalized version of the R^2 score.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_table/multi_column_pairs.py
+++ b/sdmetrics/single_table/multi_column_pairs.py
@@ -95,7 +95,7 @@ class MultiColumnPairsMetric(SingleTableMetric, metaclass=NestedAttrsMeta('colum
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_table/multi_single_column.py
+++ b/sdmetrics/single_table/multi_single_column.py
@@ -111,7 +111,7 @@ class MultiSingleColumnMetric(SingleTableMetric,
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/sdmetrics/single_table/privacy/__init__.py
+++ b/sdmetrics/single_table/privacy/__init__.py
@@ -1,3 +1,5 @@
+"""Privacy metrics module."""
+
 from sdmetrics.single_table.privacy.base import CategoricalPrivacyMetric, NumericalPrivacyMetric
 from sdmetrics.single_table.privacy.cap import (
     CategoricalCAP, CategoricalGeneralizedCAP, CategoricalZeroCAP)

--- a/sdmetrics/single_table/privacy/cap.py
+++ b/sdmetrics/single_table/privacy/cap.py
@@ -1,3 +1,5 @@
+"""CAP modules and their attackers."""
+
 from sdmetrics.single_table.privacy.base import CategoricalPrivacyMetric, PrivacyAttackerModel
 from sdmetrics.single_table.privacy.util import closest_neighbors, count_frequency, majority
 

--- a/sdmetrics/single_table/privacy/categorical_sklearn.py
+++ b/sdmetrics/single_table/privacy/categorical_sklearn.py
@@ -1,3 +1,5 @@
+"""Categorical sklearn privacy metric modules and their attackers."""
+
 import numpy as np
 import sklearn.naive_bayes
 from sklearn.ensemble import RandomForestClassifier

--- a/sdmetrics/single_table/privacy/ensemble.py
+++ b/sdmetrics/single_table/privacy/ensemble.py
@@ -1,3 +1,5 @@
+"""CategoricalEnsemble module and its attacker."""
+
 import numpy as np
 
 from sdmetrics.single_table.privacy.base import CategoricalPrivacyMetric, PrivacyAttackerModel

--- a/sdmetrics/single_table/privacy/loss.py
+++ b/sdmetrics/single_table/privacy/loss.py
@@ -1,3 +1,5 @@
+"""Utilities for the single_table.privacy modules."""
+
 import numpy as np
 from copulas.univariate.base import Univariate
 
@@ -36,7 +38,8 @@ class InverseCDFDistance(LossFunction):
     """
 
     def __init__(self, p=2):
-        """
+        """Set up the appropriate attributes.
+
         Args:
             p (float):
                 The p parameter in L_p metric. Must be positive.

--- a/sdmetrics/single_table/privacy/loss.py
+++ b/sdmetrics/single_table/privacy/loss.py
@@ -35,15 +35,13 @@ class InverseCDFDistance(LossFunction):
     This loss function first applies the fitted cdfs to every single entry (i.e. turning
     the numerical values into their respective percentiles) and then measures the Lp distance
     to the pth power, between the predicted value and the real value.
+
+    Args:
+        p (float):
+            The p parameter in L_p metric. Must be positive.
     """
 
     def __init__(self, p=2):
-        """Set up the appropriate attributes.
-
-        Args:
-            p (float):
-                The p parameter in L_p metric. Must be positive.
-        """
         self.p = p
         self.cdfs = []
 

--- a/sdmetrics/single_table/privacy/numerical_sklearn.py
+++ b/sdmetrics/single_table/privacy/numerical_sklearn.py
@@ -1,3 +1,5 @@
+"""Numerical sklearn privacy metric modules and their attackers."""
+
 import numpy as np
 from sklearn.linear_model import LinearRegression
 from sklearn.neural_network import MLPRegressor

--- a/sdmetrics/single_table/privacy/radius_nearest_neighbor.py
+++ b/sdmetrics/single_table/privacy/radius_nearest_neighbor.py
@@ -11,17 +11,15 @@ class NumericalRadiusNearestNeighborAttacker(PrivacyAttackerModel):
     It will predict the sensitive value to be a weighted mean of the entries in the
     synthetic table. Where this weight is given by a separate function, and typically
     describes the closeness between the given key and the corresponding entry in the table.
+
+    Args:
+        weight_func (Class):
+            The weight function to use.
+        weight_func_kwargs (dict):
+            Parameters of the weight function.
     """
 
     def __init__(self, weight_func=None, weight_func_kwargs=None):
-        """Set up the appropriate attributes.
-
-        Args:
-            weight_func (Class):
-                The weight function to use.
-            weight_func_kwargs (dict):
-                Parameters of the weight function.
-        """
         if weight_func_kwargs is None:
             weight_func_kwargs = {}
 

--- a/sdmetrics/single_table/privacy/radius_nearest_neighbor.py
+++ b/sdmetrics/single_table/privacy/radius_nearest_neighbor.py
@@ -1,3 +1,4 @@
+"""RadiusNearestNeighbor module and its attacker/utilities."""
 import numpy as np
 
 from sdmetrics.single_table.privacy.base import NumericalPrivacyMetric, PrivacyAttackerModel
@@ -13,7 +14,8 @@ class NumericalRadiusNearestNeighborAttacker(PrivacyAttackerModel):
     """
 
     def __init__(self, weight_func=None, weight_func_kwargs=None):
-        """
+        """Set up the appropriate attributes.
+
         Args:
             weight_func (Class):
                 The weight function to use.

--- a/sdmetrics/single_table/privacy/util.py
+++ b/sdmetrics/single_table/privacy/util.py
@@ -1,3 +1,5 @@
+"""Utils for the single_table.privacy modules."""
+
 import numpy as np
 
 

--- a/sdmetrics/timeseries/detection.py
+++ b/sdmetrics/timeseries/detection.py
@@ -93,7 +93,7 @@ class TimeSeriesDetectionMetric(TimeSeriesMetric):
 
     @classmethod
     def normalize(cls, raw_score):
-        """Returns the `raw_score` as is, since it is already normalized.
+        """Return the `raw_score` as is, since it is already normalized.
 
         Args:
             raw_score (float):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
+extend-ignore = D107
 
 [isort]
 include_trailing_comment = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
-extend-ignore = D107
+extend-ignore = D107  # Missing docstring in __init__
 
 [isort]
 include_trailing_comment = True

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ development_requires = [
     'flake8>=3.7.7,<4',
     'flake8-absolute-import>=1.0,<2',
     'isort>=4.3.4,<5',
+    'flake8-docstrings>=1.5.0,<2'
 
     # fix style issues
     'autoflake>=1.1,<2',


### PR DESCRIPTION
As part of #80, add `flake8-docstrings` and update the code to conform with it.

**Note:** rule D107 (`__init__` docstrings) is being ignored, because in general we don't add docstrings to ``__init__``'s. This is also being ignored in RDT.