### PR TITLE
Add `flake8-sfs`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
+extend-ignore = SFS3
 
 [isort]
 include_trailing_comment = True

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ development_requires = [
     'flake8>=3.7.7,<4',
     'flake8-absolute-import>=1.0,<2',
     'isort>=4.3.4,<5',
+    'flake8-sfs>=0.0.3,<0.1',
 
     # fix style issues
     'autoflake>=1.1,<2',


### PR DESCRIPTION
As part of #80, add `flake8-sfs` and update the code to match this addition.

**Note:** SFS3 (`String literal formatting using f-string`) is being ignored because we do so as well in RDT.