### PR TITLE
Specify default categorical transformers

### DIFF
--- a/sdmetrics/single_table/detection/base.py
+++ b/sdmetrics/single_table/detection/base.py
@@ -4,6 +4,7 @@ import logging
 
 import numpy as np
 from rdt import HyperTransformer
+from rdt.transformers import OneHotEncodingTransformer
 from sklearn.metrics import roc_auc_score
 from sklearn.model_selection import StratifiedKFold
 
@@ -65,7 +66,9 @@ class DetectionMetric(SingleTableMetric):
                 One minus the ROC AUC Cross Validation Score obtained by the classifier.
         """
         metadata = cls._validate_inputs(real_data, synthetic_data, metadata)
-        transformer = HyperTransformer(default_data_type_transformers={'O': 'one_hot_encoding'})
+        transformer = HyperTransformer(default_data_type_transformers={
+            'categorical': OneHotEncodingTransformer(error_on_unknown=False),
+        })
         real_data = transformer.fit_transform(real_data).to_numpy()
         synthetic_data = transformer.transform(synthetic_data).to_numpy()
 

--- a/sdmetrics/single_table/efficacy/base.py
+++ b/sdmetrics/single_table/efficacy/base.py
@@ -47,7 +47,7 @@ class MLEfficacyMetric(SingleTableMetric):
             predictions = np.full(len(real_data), unique_labels[0])
         else:
             transformer = rdt.HyperTransformer(default_data_type_transformers={
-                'O': 'one_hot_encoding'
+                'categorical': rdt.transformers.OneHotEncodingTransformer(error_on_unknown=False),
             })
             real_data = transformer.fit_transform(real_data)
             synthetic_data = transformer.transform(synthetic_data)

--- a/sdmetrics/timeseries/detection.py
+++ b/sdmetrics/timeseries/detection.py
@@ -77,8 +77,8 @@ class TimeSeriesDetectionMetric(TimeSeriesMetric):
             real_data, synthetic_data, metadata, entity_columns)
 
         transformer = rdt.HyperTransformer(default_data_type_transformers={
-            'O': 'one_hot_encoding',
-            'M': rdt.transformers.DatetimeTransformer(strip_constant=True),
+            'categorical': rdt.transformers.OneHotEncodingTransformer(error_on_unknown=False),
+            'datetime': rdt.transformers.DatetimeTransformer(strip_constant=True),
         })
         transformer.fit(real_data.drop(entity_columns, axis=1))
 

--- a/sdmetrics/timeseries/efficacy/base.py
+++ b/sdmetrics/timeseries/efficacy/base.py
@@ -64,8 +64,8 @@ class TimeSeriesEfficacyMetric(TimeSeriesMetric):
     @classmethod
     def _compute_score(cls, real_data, synthetic_data, entity_columns, target):
         transformer = rdt.HyperTransformer(default_data_type_transformers={
-            'O': 'one_hot_encoding',
-            'M': rdt.transformers.DatetimeTransformer(strip_constant=True),
+            'categorical': rdt.transformers.OneHotEncodingTransformer(error_on_unknown=False),
+            'datetime': rdt.transformers.DatetimeTransformer(strip_constant=True),
         })
         transformer.fit(real_data.drop(entity_columns + [target], axis=1))
 


### PR DESCRIPTION
Update default data type transformers keys to the expected data types. Also specify `error_on_unknown=False` to preserve the original default [OneHotEncoderTransformer behavior](https://github.com/sdv-dev/RDT/blob/v0.5.3/rdt/hyper_transformer.py#L64).

Follow up from Issue #102 