### PR TITLE
Increase max_iter of logistic regression since it generate warnings

### DIFF
--- a/sdmetrics/single_table/detection/sklearn.py
+++ b/sdmetrics/single_table/detection/sklearn.py
@@ -50,7 +50,7 @@ class LogisticDetection(ScikitLearnClassifierDetectionMetric):
 
     @staticmethod
     def _get_classifier():
-        return LogisticRegression(solver='lbfgs')
+        return LogisticRegression(solver='lbfgs', max_iter=1000)
 
 
 class SVCDetection(ScikitLearnClassifierDetectionMetric):

--- a/sdmetrics/single_table/efficacy/binary.py
+++ b/sdmetrics/single_table/efficacy/binary.py
@@ -87,7 +87,7 @@ class BinaryLogisticRegression(BinaryEfficacyMetric):
         'solver': 'lbfgs',
         'n_jobs': 2,
         'class_weight': 'balanced',
-        'max_iter': 50
+        'max_iter': 200
     }
 
 


### PR DESCRIPTION
When evaluating datasets, logistic regressions do not properly converge.
