### PR TITLE
Bug fixes for QualityReport

### DIFF
--- a/sdmetrics/reports/multi_table/plot_utils.py
+++ b/sdmetrics/reports/multi_table/plot_utils.py
@@ -53,7 +53,7 @@ def get_table_relationships_plot(score_breakdowns):
         plot_data,
         x='Child → Parent Relationship',
         y='Quality Score',
-        title=f'Column Shapes Similarity (Average={average_score})',
+        title=f'Data Quality: Table Relationships (Average Score={average_score})',
         color='Metric',
         color_discrete_sequence=[BAR_COLOR],
         hover_name='Child → Parent Relationship',

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -268,13 +268,20 @@ class QualityReport():
         metrics = list(itertools.chain.from_iterable(self.METRICS.values()))
         for metric in metrics:
             if metric.__name__ == metric_name:
+                filtered_results = {}
+                for table_name, table_results in self._metric_results[metric_name].items():
+                    filtered_results[table_name] = {
+                        key: result for key, result in table_results.items()
+                        if not np.isnan(result['score'])
+                    }
+
                 return [
                     {
                         'metric': {
                             'method': f'{metric.__module__}.{metric.__name__}',
                             'parameters': {},
                         },
-                        'results': self._metric_results[metric_name],
+                        'results': filtered_results,
                     },
                 ]
 

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -88,13 +88,16 @@ class QualityReport():
             prop_scores = []
             if prop == 'Parent Child Relationships':
                 for metric in metrics:
-                    score = np.nanmean(
-                        [
-                            table_breakdown['score'] for _, table_breakdown
-                            in self._metric_results['CardinalityShapeSimilarity'].items()
-                        ]
-                    )
-                    prop_scores.append(score)
+                    if 'score' in self._metric_results[metric.__name__]:
+                        prop_scores.append(self._metric_results[metric.__name__]['score'])
+                    else:
+                        score = np.nanmean(
+                            [
+                                table_breakdown['score'] for _, table_breakdown
+                                in self._metric_results[metric.__name__].items()
+                            ]
+                        )
+                        prop_scores.append(score)
             else:
                 for metric in metrics:
                     score = np.nanmean(
@@ -106,9 +109,9 @@ class QualityReport():
                     )
                     prop_scores.append(score)
 
-            self._property_breakdown[prop] = np.mean(prop_scores)
+            self._property_breakdown[prop] = np.nanmean(prop_scores)
 
-        self._overall_quality_score = np.mean(list(self._property_breakdown.values()))
+        self._overall_quality_score = np.nanmean(list(self._property_breakdown.values()))
 
         self._print_results()
 

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -34,8 +34,6 @@ class QualityReport():
         self._overall_quality_score = None
         self._metric_results = {}
         self._property_breakdown = {}
-        self._real_corrs = {}
-        self._synth_corrs = {}
 
     def _print_results(self, out=sys.stdout):
         """Print the quality report results."""
@@ -110,11 +108,6 @@ class QualityReport():
 
             self._property_breakdown[prop] = np.mean(prop_scores)
 
-        # Calculate and store the correlation matrices.
-        for table_name, table_data in real_data.items():
-            self._real_corrs[table_name] = table_data.corr()
-            self._synth_corrs[table_name] = synthetic_data[table_name].corr()
-
         self._overall_quality_score = np.mean(list(self._property_breakdown.values()))
 
         self._print_results()
@@ -168,8 +161,6 @@ class QualityReport():
             }
             fig = get_column_pairs_plot(
                 score_breakdowns,
-                self._real_corrs[table_name],
-                self._synth_corrs[table_name],
             )
 
         elif property_name == 'Parent Child Relationships':
@@ -277,10 +268,15 @@ class QualityReport():
         metrics = list(itertools.chain.from_iterable(self.METRICS.values()))
         for metric in metrics:
             if metric.__name__ == metric_name:
-                return {
-                    'metric': f'{metric.__module__}.{metric.__name__}',
-                    'results': self._metric_results[metric_name],
-                }
+                return [
+                    {
+                        'metric': {
+                            'method': f'{metric.__module__}.{metric.__name__}',
+                            'parameters': {},
+                        },
+                        'results': self._metric_results[metric_name],
+                    },
+                ]
 
     def save(self, filename):
         """Save this report instance to the given path using pickle.

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -37,13 +37,16 @@ class QualityReport():
 
     def _print_results(self, out=sys.stdout):
         """Print the quality report results."""
-        out.write(f'\nOverall Quality Score: {self._overall_quality_score}\n\n')
+        out.write(f'\nOverall Quality Score: {round(self._overall_quality_score * 100, 2)}%\n\n')
 
         if len(self._property_breakdown) > 0:
             out.write('Properties:\n')
 
         for prop, score in self._property_breakdown.items():
-            out.write(f'{prop}: {round(score * 100, 2)}%\n')
+            if not np.isnan(score):
+                out.write(f'{prop}: {round(score * 100, 2)}%\n')
+            else:
+                out.write(f'{prop}: NaN\n')
 
     def generate(self, real_data, synthetic_data, metadata):
         """Generate report.
@@ -109,9 +112,7 @@ class QualityReport():
                     )
                     prop_scores.append(score)
 
-            self._property_breakdown[prop] = np.nan
-            if len(prop_scores) > 0:
-                self._property_breakdown[prop] = np.nanmean(prop_scores)
+            self._property_breakdown[prop] = np.nanmean(prop_scores)
 
         self._overall_quality_score = np.nanmean(list(self._property_breakdown.values()))
 

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -244,7 +244,8 @@ class QualityReport():
 
             return pd.DataFrame({
                 'Table': tables,
-                'Columns': columns,
+                'Column 1': [col1 for col1, _ in columns],
+                'Column 2': [col2 for _, col2 in columns],
                 'Metric': metrics,
                 'Quality Score': scores,
                 'Real Correlation': real_scores,

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -109,7 +109,9 @@ class QualityReport():
                     )
                     prop_scores.append(score)
 
-            self._property_breakdown[prop] = np.nanmean(prop_scores)
+            self._property_breakdown[prop] = np.nan
+            if len(prop_scores) > 0:
+                self._property_breakdown[prop] = np.nanmean(prop_scores)
 
         self._overall_quality_score = np.nanmean(list(self._property_breakdown.values()))
 

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -301,27 +301,27 @@ class QualityReport():
                     },
                 ]
 
-    def save(self, filename):
+    def save(self, filepath):
         """Save this report instance to the given path using pickle.
 
         Args:
-            filename (str):
-                File where the report instance will be serialized.
+            filepath (str):
+                The path to the file where the report instance will be serialized.
         """
-        with open(filename, 'wb') as output:
+        with open(filepath, 'wb') as output:
             pickle.dump(self, output)
 
     @classmethod
-    def load(cls, filename):
+    def load(cls, filepath):
         """Load a ``QualityReport`` instance from a given path.
 
         Args:
-            filename (str):
-                File from which to load the instance.
+            filepath (str):
+                The path to the file where the report is stored.
 
         Returns:
             QualityReort:
                 The loaded quality report instance.
         """
-        with open(filename, 'rb') as f:
+        with open(filepath, 'rb') as f:
             return pickle.load(f)

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -218,11 +218,11 @@ class QualityReport():
                         scores.append(score_breakdown['score'])
 
             return pd.DataFrame({
-                'Table Name': tables,
+                'Table': tables,
                 'Column': columns,
                 'Metric': metrics,
                 'Quality Score': scores,
-            })
+            }).sort_values(by=['Table'], ignore_index=True)
 
         elif property_name == 'Column Pair Trends':
             real_scores = []
@@ -243,13 +243,13 @@ class QualityReport():
                             score_breakdown['synthetic'] if 'real' in score_breakdown else np.nan)
 
             return pd.DataFrame({
-                'Table Name': tables,
+                'Table': tables,
                 'Columns': columns,
                 'Metric': metrics,
                 'Quality Score': scores,
-                'Real Score': real_scores,
-                'Synthetic Score': synthetic_scores,
-            })
+                'Real Correlation': real_scores,
+                'Synthetic Correlation': synthetic_scores,
+            }).sort_values(by=['Table'], ignore_index=True)
 
         elif property_name == 'Parent Child Relationships':
             child_tables = []

--- a/sdmetrics/reports/multi_table/quality_report.py
+++ b/sdmetrics/reports/multi_table/quality_report.py
@@ -174,6 +174,13 @@ class QualityReport():
                 metric.__name__: self._metric_results[metric.__name__]
                 for metric in self.METRICS.get(property_name, [])
             }
+            if table_name is not None:
+                for metric, metric_results in score_breakdowns.items():
+                    score_breakdowns[metric] = {
+                        tables: results for tables, results in metric_results.items()
+                        if table_name in tables
+                    }
+
             fig = get_table_relationships_plot(score_breakdowns)
 
         fig.show()
@@ -248,6 +255,9 @@ class QualityReport():
             child_tables = []
             for metric in self.METRICS[property_name]:
                 for table_pair, score_breakdown in self._metric_results[metric.__name__].items():
+                    if table_name is not None and table_name not in table_pair:
+                        continue
+
                     tables.append(table_pair[0])
                     child_tables.append(table_pair[1])
                     metrics.append(metric.__name__)

--- a/sdmetrics/reports/single_table/plot_utils.py
+++ b/sdmetrics/reports/single_table/plot_utils.py
@@ -204,12 +204,14 @@ def get_column_pairs_plot(score_breakdowns, average_score=None):
         go.Heatmap(
             x=similarity_correlation.columns,
             y=similarity_correlation.columns,
-            z=similarity_correlation,
+            z=similarity_correlation.round(2),
             coloraxis='coloraxis',
             xaxis='x',
             yaxis='y',
-            hovertemplate=('<b>Column Pair</b><br>(%{x},%{y})<br><br>Similarity: '
-                           '%{z:.2f}<extra></extra>'),
+            hovertemplate=(
+                '<b>Column Pair</b><br>(%{x},%{y})<br><br>Similarity: '
+                '%{z}<extra></extra>'
+            ),
         ),
         1,
         1,
@@ -220,14 +222,16 @@ def get_column_pairs_plot(score_breakdowns, average_score=None):
         go.Heatmap(
             x=real_correlation.columns,
             y=real_correlation.columns,
-            z=real_correlation,
+            z=real_correlation.round(2),
             coloraxis='coloraxis2',
             xaxis='x2',
             yaxis='y2',
             # Compare against synthetic data in the tooltip.
-            customdata=synthetic_correlation,
-            hovertemplate=('<b>Correlation</b><br>(%{x},%{y})<br><br>Real: %{z:.2f}'
-                           '<br>(vs. Synthetic: %{customdata:.2f})<extra></extra>'),
+            customdata=synthetic_correlation.round(2),
+            hovertemplate=(
+                '<b>Correlation</b><br>(%{x},%{y})<br><br>Real: %{z}'
+                '<br>(vs. Synthetic: %{customdata})<extra></extra>'
+            ),
         ),
         2,
         1,
@@ -238,14 +242,16 @@ def get_column_pairs_plot(score_breakdowns, average_score=None):
         go.Heatmap(
             x=synthetic_correlation.columns,
             y=synthetic_correlation.columns,
-            z=synthetic_correlation,
+            z=synthetic_correlation.round(2),
             coloraxis='coloraxis2',
             xaxis='x3',
             yaxis='y3',
             # Compare against real data in the tooltip.
-            customdata=real_correlation,
-            hovertemplate=('<b>Correlation</b><br>(%{x},%{y})<br><br>Synthetic: '
-                           '%{z:.2f}<br>(vs. Real: %{customdata:.2f})<extra></extra>'),
+            customdata=real_correlation.round(2),
+            hovertemplate=(
+                '<b>Correlation</b><br>(%{x},%{y})<br><br>Synthetic: '
+                '%{z}<br>(vs. Real: %{customdata})<extra></extra>'
+            ),
         ),
         2,
         2,
@@ -260,7 +266,7 @@ def get_column_pairs_plot(score_breakdowns, average_score=None):
             'colorbar_y': 0.8,
             'cmin': 0,
             'cmax': 1,
-            'colorscale': 'Orrd_r'
+            'colorscale': ['#FF0000', '#F16141', '#36B37E'],
         },
         # Correlation heatmaps color axis
         coloraxis2={

--- a/sdmetrics/reports/single_table/plot_utils.py
+++ b/sdmetrics/reports/single_table/plot_utils.py
@@ -51,7 +51,7 @@ def get_column_shapes_plot(score_breakdowns, average_score=None):
         data,
         x='Column Name',
         y='Quality Score',
-        title=f'Column Shapes Similarity (Average={round(average_score, 2)})',
+        title=f'Data Quality: Column Shapes (Average Score={round(average_score, 2)})',
         category_orders={'group': data['Column Name']},
         color='Metric',
         color_discrete_map={
@@ -178,9 +178,9 @@ def get_column_pairs_plot(score_breakdowns, average_score=None):
         rows=2,
         cols=2,
         subplot_titles=[
-            f'Column Pairs Similarity ({round(average_score, 2)})',
-            'Numerical Correlation (Real)',
-            'Numerical Correlation (Synthetic)',
+            'Real vs. Synthetic Similarity',
+            'Real Trends (Numerical Data)',
+            'Real Trends (Synthetic Data)',
         ],
         specs=[[{'colspan': 2, 'l': 0.26, 'r': 0.26}, None], [{}, {}]])
 
@@ -237,7 +237,7 @@ def get_column_pairs_plot(score_breakdowns, average_score=None):
     )
 
     fig.update_layout(
-        title_text='Column Pair Trends',
+        title_text=f'Data Quality: Column Pair Trends (Average Score={round(average_score, 2)})',
         # Similarity heatmap color axis
         coloraxis={
             'colorbar_len': 0.5,

--- a/sdmetrics/reports/single_table/plot_utils.py
+++ b/sdmetrics/reports/single_table/plot_utils.py
@@ -117,8 +117,10 @@ def _get_numerical_correlation_matrices(score_breakdowns):
     """
     columns = []
     for cols, _ in score_breakdowns['CorrelationSimilarity'].items():
-        columns.append(cols[0])
-        columns.append(cols[1])
+        if cols[0] not in columns:
+            columns.append(cols[0])
+        if cols[1] not in columns:
+            columns.append(cols[1])
 
     real_correlation = pd.DataFrame(
         index=columns,

--- a/sdmetrics/reports/single_table/plot_utils.py
+++ b/sdmetrics/reports/single_table/plot_utils.py
@@ -72,7 +72,22 @@ def get_column_shapes_plot(score_breakdowns, average_score=None):
 
     fig.update_layout(
         xaxis_categoryorder='total ascending',
-        plot_bgcolor='#F5F5F8'
+        plot_bgcolor='#F5F5F8',
+        margin={'t': 150},
+        annotations=[
+            {
+                'font': {'color': 'black', 'size': 11},
+                'xref': 'paper',
+                'yref': 'paper',
+                'x': -0.045,
+                'y': 1.25,
+                'showarrow': False,
+                'text': (
+                    'KSComplement is applied to numerical & datetime columns. '
+                    'TVComplement is applied for boolean & categorical columns.'
+                ),
+            },
+        ],
     )
 
     return fig

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -55,9 +55,7 @@ class QualityReport():
         metrics = list(itertools.chain.from_iterable(self.METRICS.values()))
 
         for metric in tqdm.tqdm(metrics, desc='Creating report'):
-            metric_name = metric.__name__
-
-            self._metric_results[metric_name] = metric.compute_breakdown(
+            self._metric_results[metric.__name__] = metric.compute_breakdown(
                 real_data, synthetic_data, metadata)
 
         existing_column_pairs = list(self._metric_results['ContingencySimilarity'].keys())
@@ -79,7 +77,9 @@ class QualityReport():
                 )
                 prop_scores.append(score)
 
-            self._property_breakdown[prop] = np.nanmean(prop_scores)
+            self._property_breakdown[prop] = np.nan
+            if len(prop_scores) > 0:
+                self._property_breakdown[prop] = np.nanmean(prop_scores)
 
         self._overall_quality_score = np.nanmean(list(self._property_breakdown.values()))
 

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -175,7 +175,8 @@ class QualityReport():
                         score_breakdown['synthetic'] if 'synthetic' in score_breakdown else np.nan)
 
             return pd.DataFrame({
-                'Columns': columns,
+                'Column 1': [col1 for col1, _ in columns],
+                'Column 2': [col2 for _, col2 in columns],
                 'Metric': metrics,
                 'Quality Score': scores,
                 'Real Correlation': real_scores,

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -30,8 +30,6 @@ class QualityReport():
         self._overall_quality_score = None
         self._metric_results = {}
         self._property_breakdown = {}
-        self._real_corr = None
-        self._synth_corr = None
 
     def _print_results(self, out=sys.stdout):
         """Print the quality report results."""
@@ -63,7 +61,7 @@ class QualityReport():
                 real_data, synthetic_data, metadata)
 
         existing_column_pairs = list(self._metric_results['ContingencySimilarity'].keys())
-        existing_column_pairs.append(
+        existing_column_pairs.extend(
             list(self._metric_results['CorrelationSimilarity'].keys()))
         additional_results = discretize_and_apply_metric(
             real_data, synthetic_data, metadata, ContingencySimilarity, existing_column_pairs)
@@ -82,10 +80,6 @@ class QualityReport():
                 prop_scores.append(score)
 
             self._property_breakdown[prop] = np.mean(prop_scores)
-
-        # Calculate and store the correlation matrices.
-        self._real_corr = real_data.corr()
-        self._synth_corr = synthetic_data.corr()
 
         self._overall_quality_score = np.mean(list(self._property_breakdown.values()))
 
@@ -130,8 +124,6 @@ class QualityReport():
         elif property_name == 'Column Pair Trends':
             fig = get_column_pairs_plot(
                 score_breakdowns,
-                self._real_corr,
-                self._synth_corr,
                 self._property_breakdown[property_name],
             )
 
@@ -203,10 +195,15 @@ class QualityReport():
         metrics = list(itertools.chain.from_iterable(self.METRICS.values()))
         for metric in metrics:
             if metric.__name__ == metric_name:
-                return {
-                    'metric': f'{metric.__module__}.{metric.__name__}',
-                    'results': self._metric_results[metric_name],
-                }
+                return [
+                    {
+                        'metric': {
+                            'method': f'{metric.__module__}.{metric.__name__}',
+                            'parameters': {},
+                        },
+                        'results': self._metric_results[metric_name],
+                    },
+                ]
 
     def save(self, filename):
         """Save this report instance to the given path using pickle.

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -210,27 +210,27 @@ class QualityReport():
                     },
                 ]
 
-    def save(self, filename):
+    def save(self, filepath):
         """Save this report instance to the given path using pickle.
 
         Args:
-            filename (str):
-                File where the report instance will be serialized.
+            filepath (str):
+                The path to the file where the report instance will be serialized.
         """
-        with open(filename, 'wb') as output:
+        with open(filepath, 'wb') as output:
             pickle.dump(self, output)
 
     @classmethod
-    def load(cls, filename):
+    def load(cls, filepath):
         """Load a ``QualityReport`` instance from a given path.
 
         Args:
-            filename (str):
-                File from which to load the instance.
+            filepath (str):
+                The path to the file where the report is stored.
 
         Returns:
             QualityReort:
                 The loaded quality report instance.
         """
-        with open(filename, 'rb') as f:
+        with open(filepath, 'rb') as f:
             return pickle.load(f)

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -178,8 +178,8 @@ class QualityReport():
                 'Columns': columns,
                 'Metric': metrics,
                 'Quality Score': scores,
-                'Real Score': real_scores,
-                'Synthetic Score': synthetic_scores,
+                'Real Correlation': real_scores,
+                'Synthetic Correlation': synthetic_scores,
             })
 
     def get_raw_result(self, metric_name):

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -33,13 +33,16 @@ class QualityReport():
 
     def _print_results(self, out=sys.stdout):
         """Print the quality report results."""
-        out.write(f'\nOverall Quality Score: {self._overall_quality_score}\n\n')
+        out.write(f'\nOverall Quality Score: {round(self._overall_quality_score * 100, 2)}%\n\n')
 
         if len(self._property_breakdown) > 0:
             out.write('Properties:\n')
 
         for prop, score in self._property_breakdown.items():
-            out.write(f'{prop}: {round(score * 100, 2)}%\n')
+            if not np.isnan(score):
+                out.write(f'{prop}: {round(score * 100, 2)}%\n')
+            else:
+                out.write(f'{prop}: NaN\n')
 
     def generate(self, real_data, synthetic_data, metadata):
         """Generate report.
@@ -77,9 +80,7 @@ class QualityReport():
                 )
                 prop_scores.append(score)
 
-            self._property_breakdown[prop] = np.nan
-            if len(prop_scores) > 0:
-                self._property_breakdown[prop] = np.nanmean(prop_scores)
+            self._property_breakdown[prop] = np.nanmean(prop_scores)
 
         self._overall_quality_score = np.nanmean(list(self._property_breakdown.values()))
 

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -79,9 +79,9 @@ class QualityReport():
                 )
                 prop_scores.append(score)
 
-            self._property_breakdown[prop] = np.mean(prop_scores)
+            self._property_breakdown[prop] = np.nanmean(prop_scores)
 
-        self._overall_quality_score = np.mean(list(self._property_breakdown.values()))
+        self._overall_quality_score = np.nanmean(list(self._property_breakdown.values()))
 
         self._print_results()
 

--- a/sdmetrics/reports/single_table/quality_report.py
+++ b/sdmetrics/reports/single_table/quality_report.py
@@ -201,7 +201,11 @@ class QualityReport():
                             'method': f'{metric.__module__}.{metric.__name__}',
                             'parameters': {},
                         },
-                        'results': self._metric_results[metric_name],
+                        'results': {
+                            key: result for key, result in
+                            self._metric_results[metric_name].items()
+                            if not np.isnan(result['score'])
+                        },
                     },
                 ]
 

--- a/sdmetrics/reports/utils.py
+++ b/sdmetrics/reports/utils.py
@@ -254,12 +254,16 @@ def discretize_and_apply_metric(real_data, synthetic_data, metadata, metric, key
         field_meta['type'] != 'id'
     ]
     for columns in itertools.combinations(non_id_cols, r=2):
-        if columns not in keys_to_skip and (columns[1], columns[0]) not in keys_to_skip:
+        sorted_columns = tuple(sorted(columns))
+        if (
+            sorted_columns not in keys_to_skip and
+            (sorted_columns[1], sorted_columns[0]) not in keys_to_skip
+        ):
             result = metric.column_pairs_metric.compute_breakdown(
-                binned_real[list(columns)],
-                binned_synthetic[list(columns)],
+                binned_real[list(sorted_columns)],
+                binned_synthetic[list(sorted_columns)],
             )
-            metric_results[columns] = result
-            metric_results[columns] = result
+            metric_results[sorted_columns] = result
+            metric_results[sorted_columns] = result
 
     return metric_results

--- a/sdmetrics/reports/utils.py
+++ b/sdmetrics/reports/utils.py
@@ -32,12 +32,13 @@ def make_discrete_column_plot(real_column, synthetic_column, sdtype):
 
     real_data = pd.DataFrame({'values': real_column.copy()})
     real_data['Data'] = 'Real'
-
     synthetic_data = pd.DataFrame({'values': synthetic_column.copy()})
     synthetic_data['Data'] = 'Synthetic'
 
+    missing_data_real = round((real_column.isna().sum() / len(real_column)) * 100, 2)
+    missing_data_synthetic = round((synthetic_column.isna().sum() / len(synthetic_column)), 2)
+
     all_data = pd.concat([real_data, synthetic_data], axis=0, ignore_index=True)
-    all_data = all_data.fillna('NaN')
 
     fig = px.histogram(
         all_data,
@@ -65,6 +66,19 @@ def make_discrete_column_plot(real_column, synthetic_column, sdtype):
         xaxis_title='Category',
         yaxis_title='Frequency',
         plot_bgcolor='#F5F5F8',
+        annotations=[
+            {
+                'xref': 'paper',
+                'yref': 'paper',
+                'x': -0.08,
+                'y': -0.2,
+                'showarrow': False,
+                'text': (
+                    f'*Missing Values: Real Data ({missing_data_real}%), '
+                    f'Synthetic Data ({missing_data_synthetic}%)'
+                ),
+            },
+        ]
     )
 
     return fig

--- a/sdmetrics/reports/utils.py
+++ b/sdmetrics/reports/utils.py
@@ -37,6 +37,7 @@ def make_discrete_column_plot(real_column, synthetic_column, sdtype):
     synthetic_data['Data'] = 'Synthetic'
 
     all_data = pd.concat([real_data, synthetic_data], axis=0, ignore_index=True)
+    all_data = all_data.fillna('NaN')
 
     fig = px.histogram(
         all_data,
@@ -231,7 +232,7 @@ def discretize_and_apply_metric(real_data, synthetic_data, metadata, metric, key
         field_meta['type'] != 'id'
     ]
     for columns in itertools.combinations(non_id_cols, r=2):
-        if columns not in keys_to_skip:
+        if columns not in keys_to_skip and (columns[1], columns[0]) not in keys_to_skip:
             result = metric.column_pairs_metric.compute_breakdown(
                 binned_real[list(columns)],
                 binned_synthetic[list(columns)],

--- a/sdmetrics/reports/utils.py
+++ b/sdmetrics/reports/utils.py
@@ -61,24 +61,28 @@ def make_discrete_column_plot(real_column, synthetic_column, sdtype):
         selector={'name': 'Synthetic'}
     )
 
+    show_missing_values = missing_data_real > 0 or missing_data_synthetic > 0
+
+    annotations = [] if not show_missing_values else [
+        {
+            'xref': 'paper',
+            'yref': 'paper',
+            'x': -0.08,
+            'y': -0.2,
+            'showarrow': False,
+            'text': (
+                f'*Missing Values: Real Data ({missing_data_real}%), '
+                f'Synthetic Data ({missing_data_synthetic}%)'
+            ),
+        },
+    ]
+
     fig.update_layout(
         title=f"Real vs. Synthetic Data for column '{column_name}'",
-        xaxis_title='Category',
+        xaxis_title='Category*' if show_missing_values else 'Category',
         yaxis_title='Frequency',
         plot_bgcolor='#F5F5F8',
-        annotations=[
-            {
-                'xref': 'paper',
-                'yref': 'paper',
-                'x': -0.08,
-                'y': -0.2,
-                'showarrow': False,
-                'text': (
-                    f'*Missing Values: Real Data ({missing_data_real}%), '
-                    f'Synthetic Data ({missing_data_synthetic}%)'
-                ),
-            },
-        ]
+        annotations=annotations,
     )
 
     return fig
@@ -131,24 +135,28 @@ def make_continuous_column_plot(real_column, synthetic_column, sdtype):
         selector={'name': 'Synthetic'}
     )
 
+    show_missing_values = missing_data_real > 0 or missing_data_synthetic > 0
+
+    annotations = [] if not show_missing_values else [
+        {
+            'xref': 'paper',
+            'yref': 'paper',
+            'x': -0.08,
+            'y': -0.2,
+            'showarrow': False,
+            'text': (
+                f'*Missing Values: Real Data ({missing_data_real}%), '
+                f'Synthetic Data ({missing_data_synthetic}%)'
+            ),
+        },
+    ]
+
     fig.update_layout(
         title=f'Real vs. Synthetic Data for column {column_name}',
-        xaxis_title='Value',
+        xaxis_title='Value*' if show_missing_values else 'Value',
         yaxis_title='Frequency',
         plot_bgcolor='#F5F5F8',
-        annotations=[
-            {
-                'xref': 'paper',
-                'yref': 'paper',
-                'x': -0.08,
-                'y': -0.2,
-                'showarrow': False,
-                'text': (
-                    f'*Missing Values: Real Data ({missing_data_real}%), '
-                    f'Synthetic Data ({missing_data_synthetic}%)'
-                ),
-            },
-        ]
+        annotations=annotations,
     )
 
     return fig

--- a/sdmetrics/single_table/multi_column_pairs.py
+++ b/sdmetrics/single_table/multi_column_pairs.py
@@ -121,9 +121,10 @@ class MultiColumnPairsMetric(
 
         breakdown = {}
         for columns in combinations(fields, r=2):
-            real = real_data[list(columns)]
-            synthetic = synthetic_data[list(columns)]
-            breakdown[columns] = cls.column_pairs_metric.compute_breakdown(
+            sorted_columns = tuple(sorted(columns))
+            real = real_data[list(sorted_columns)]
+            synthetic = synthetic_data[list(sorted_columns)]
+            breakdown[sorted_columns] = cls.column_pairs_metric.compute_breakdown(
                 real, synthetic, **kwargs)
 
         return breakdown

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -316,11 +316,6 @@ class TestQualityReport:
             'table2': {('col7', 'col8'): {'score': 'other_score'}},
         }
 
-        mock_real_corr = Mock()
-        report._real_corrs = {'table1': mock_real_corr}
-        mock_synth_corr = Mock()
-        report._synth_corrs = {'table1': mock_synth_corr}
-
         # Run
         report.show_details('Column Pair Trends', table_name='table1')
 
@@ -328,7 +323,7 @@ class TestQualityReport:
         get_plot_mock.assert_called_once_with({
             'CorrelationSimilarity': {('col1', 'col2'): {'score': 'test_score_1'}},
             'ContingencySimilarity': {('col5', 'col6'): {'score': 'test_score_2'}},
-        }, mock_real_corr, mock_synth_corr)
+        })
 
     @patch('sdmetrics.reports.multi_table.quality_report.get_table_relationships_plot')
     def test_show_details_table_relationships(self, get_plot_mock):

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -134,6 +134,114 @@ class TestQualityReport:
             'Parent Child Relationships': 1.0,
         }
 
+    @patch('sdmetrics.reports.multi_table.quality_report.discretize_and_apply_metric')
+    def test_generate_single_table(self, mock_discretize_and_apply_metric):
+        """Test the ``generate`` method when there's only one table.
+
+        Expect that the multi-table metrics are called. Expect that the parent-child
+        property score is NaN.
+
+        Setup:
+        - Mock the expected multi-table metric compute breakdown calls.
+
+        Input:
+        - Real data.
+        - Synthetic data.
+        - Metadata.
+
+        Side Effects:
+        - Expect that each multi table metric's ``compute_breakdown`` methods are called once.
+        - Expect that the ``_overall_quality_score`` and ``_property_breakdown`` attributes
+          are populated.
+        """
+        # Setup
+        mock_discretize_and_apply_metric.return_value = {}
+        real_data = {
+            'table1': pd.DataFrame({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']}),
+            'table2': pd.DataFrame({'col1': [1, 1, 1]}),
+        }
+        synthetic_data = {
+            'table1': pd.DataFrame({'col1': [1, 3, 3], 'col2': ['b', 'b', 'c']}),
+            'table2': pd.DataFrame({'col1': [3, 1, 3]}),
+        }
+        metadata = {
+            'tables': {
+                'table1': {'col1': {'type': 'numerical'}, 'col2': {'type': 'categorical'}},
+                'table2': {'col1': {'type': 'numerical'}},
+            },
+        }
+
+        ks_complement_mock = Mock()
+        ks_complement_mock.__name__ = 'KSComplement'
+        ks_complement_mock.compute_breakdown.return_value = {
+            'table1': {
+                'col1': {'score': 0.1},
+                'col2': {'score': 0.2},
+            }
+        }
+
+        tv_complement_mock = Mock()
+        tv_complement_mock.__name__ = 'TVComplement'
+        tv_complement_mock.compute_breakdown.return_value = {
+            'table1': {
+                'col1': {'score': 0.1},
+                'col2': {'score': 0.2},
+            }
+        }
+
+        corr_sim_mock = Mock()
+        corr_sim_mock.__name__ = 'CorrelationSimilarity'
+        corr_sim_mock.compute_breakdown.return_value = {
+            'table1': {
+                'col1': {'score': 0.1},
+                'col2': {'score': 0.2},
+            }
+        }
+
+        cont_sim_mock = Mock()
+        cont_sim_mock.__name__ = 'ContingencySimilarity'
+        cont_sim_mock.compute_breakdown.return_value = {
+            'table1': {
+                'col1': {'score': 0.1},
+                'col2': {'score': 0.2},
+            }
+        }
+
+        cardinality_mock = Mock()
+        cardinality_mock.__name__ = 'CardinalityShapeSimilarity'
+        cardinality_mock.compute_breakdown.return_value = {
+            'score': np.nan,
+        }
+        metrics_mock = {
+            'Column Shapes': [ks_complement_mock, tv_complement_mock],
+            'Column Pair Trends': [corr_sim_mock, cont_sim_mock],
+            'Parent Child Relationships': [cardinality_mock],
+        }
+
+        # Run
+        with patch.object(
+            QualityReport,
+            'METRICS',
+            metrics_mock,
+        ):
+            report = QualityReport()
+            report.generate(real_data, synthetic_data, metadata)
+
+        # Assert
+        ks_complement_mock.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        tv_complement_mock.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        corr_sim_mock.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        cont_sim_mock.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        cardinality_mock.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+
+        assert report._overall_quality_score == 0.15000000000000002
+        assert np.isnan(report._property_breakdown['Parent Child Relationships'])
+
     def test_get_score(self):
         """Test the ``get_score`` method.
 

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -1,6 +1,7 @@
 import pickle
 from unittest.mock import Mock, mock_open, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -486,7 +487,8 @@ class TestQualityReport:
     def test_get_raw_result(self):
         """Test the ``get_raw_result`` method.
 
-        Expect that the raw result of the desired metric is returned.
+        Expect that the raw result of the desired metric is returned. Expect that null scores
+        are excluded.
 
         Input:
         - metric name
@@ -501,6 +503,7 @@ class TestQualityReport:
                 'table1': {
                     'col1': {'score': 0.1},
                     'col2': {'score': 0.2},
+                    'col3': {'score': np.nan},
                 },
             },
         }

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -462,6 +462,34 @@ class TestQualityReport:
             },
         })
 
+    @patch('sdmetrics.reports.multi_table.quality_report.get_table_relationships_plot')
+    def test_show_details_table_relationships_with_table_name(self, get_plot_mock):
+        """Test the ``show_details`` method with Parent Child Relationships and a table.
+
+        Input:
+        - property='Parent Child Relationships'
+        - table name
+
+        Side Effects:
+        - get_parent_child_relationships_plot is called with the expected score breakdowns.
+        """
+        # Setup
+        report = QualityReport()
+        report._metric_results['CardinalityShapeSimilarity'] = {
+            ('table1', 'table2'): {'score': 'test_score_1'},
+            ('table3', 'table2'): {'score': 'test_score_2'},
+        }
+
+        # Run
+        report.show_details('Parent Child Relationships', table_name='table1')
+
+        # Assert
+        get_plot_mock.assert_called_once_with({
+            'CardinalityShapeSimilarity': {
+                ('table1', 'table2'): {'score': 'test_score_1'},
+            },
+        })
+
     def test_get_details_column_shapes(self):
         """Test the ``get_details`` method with column shapes.
 
@@ -589,6 +617,41 @@ class TestQualityReport:
                 'Parent Table': ['table1', 'table1'],
                 'Metric': ['CardinalityShapeSimilarity', 'CardinalityShapeSimilarity'],
                 'Quality Score': [0.1, 0.2],
+            })
+        )
+
+    def test_get_details_parent_child_relationships_with_table_name(self):
+        """Test the ``get_details`` method with parent child relationships with a table filter.
+
+        Expect that the details of the desired property is returned.
+
+        Input:
+        - property name
+        - table name
+
+        Output:
+        - score details for the desired property
+        """
+        # Setup
+        report = QualityReport()
+        report._metric_results = {
+            'CardinalityShapeSimilarity': {
+                ('table1', 'table2'): {'score': 0.1},
+                ('table1', 'table3'): {'score': 0.2},
+            },
+        }
+
+        # Run
+        out = report.get_details('Parent Child Relationships', table_name='table2')
+
+        # Assert
+        pd.testing.assert_frame_equal(
+            out,
+            pd.DataFrame({
+                'Child Table': ['table2'],
+                'Parent Table': ['table1'],
+                'Metric': ['CardinalityShapeSimilarity'],
+                'Quality Score': [0.1],
             })
         )
 

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -509,12 +509,17 @@ class TestQualityReport:
         out = report.get_raw_result('KSComplement')
 
         # Assert
-        assert out == {
-            'metric': 'sdmetrics.multi_table.multi_single_table.KSComplement',
-            'results': {
-                'table1': {
-                    'col1': {'score': 0.1},
-                    'col2': {'score': 0.2},
+        assert out == [
+            {
+                'metric': {
+                    'method': 'sdmetrics.multi_table.multi_single_table.KSComplement',
+                    'parameters': {},
+                },
+                'results': {
+                    'table1': {
+                        'col1': {'score': 0.1},
+                        'col2': {'score': 0.2},
+                    }
                 }
             }
-        }
+        ]

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -581,12 +581,8 @@ class TestQualityReport:
             out,
             pd.DataFrame({
                 'Table': ['table1', 'table1', 'table1', 'table1'],
-                'Columns': [
-                    ('col1', 'col3'),
-                    ('col2', 'col4'),
-                    ('col1', 'col3'),
-                    ('col2', 'col4'),
-                ],
+                'Column 1': ['col1', 'col2', 'col1', 'col2'],
+                'Column 2': ['col3', 'col4', 'col3', 'col4'],
                 'Metric': [
                     'CorrelationSimilarity',
                     'CorrelationSimilarity',

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -268,7 +268,7 @@ class TestQualityReport:
         assert score == mock_score
 
     def test_get_properties(self):
-        """Test the ``get_details`` method.
+        """Test the ``get_properties`` method.
 
         Expect that the property score breakdown is returned.
 
@@ -509,11 +509,17 @@ class TestQualityReport:
                     'col1': {'score': 0.1},
                     'col2': {'score': 0.2},
                 },
+                'table2': {
+                    'col3': {'score': 0.5},
+                },
             },
             'TVComplement': {
                 'table1': {
                     'col1': {'score': 0.3},
                     'col2': {'score': 0.4},
+                },
+                'table2': {
+                    'col3': {'score': 0.6},
                 },
             }
         }
@@ -525,10 +531,17 @@ class TestQualityReport:
         pd.testing.assert_frame_equal(
             out,
             pd.DataFrame({
-                'Table Name': ['table1', 'table1', 'table1', 'table1'],
-                'Column': ['col1', 'col2', 'col1', 'col2'],
-                'Metric': ['KSComplement', 'KSComplement', 'TVComplement', 'TVComplement'],
-                'Quality Score': [0.1, 0.2, 0.3, 0.4],
+                'Table': ['table1', 'table1', 'table1', 'table1', 'table2', 'table2'],
+                'Column': ['col1', 'col2', 'col1', 'col2', 'col3', 'col3'],
+                'Metric': [
+                    'KSComplement',
+                    'KSComplement',
+                    'TVComplement',
+                    'TVComplement',
+                    'KSComplement',
+                    'TVComplement',
+                ],
+                'Quality Score': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
             })
         )
 
@@ -567,7 +580,7 @@ class TestQualityReport:
         pd.testing.assert_frame_equal(
             out,
             pd.DataFrame({
-                'Table Name': ['table1', 'table1', 'table1', 'table1'],
+                'Table': ['table1', 'table1', 'table1', 'table1'],
                 'Columns': [
                     ('col1', 'col3'),
                     ('col2', 'col4'),
@@ -581,8 +594,8 @@ class TestQualityReport:
                     'ContingencySimilarity',
                 ],
                 'Quality Score': [0.1, 0.2, 0.3, 0.4],
-                'Real Score': [0.1, 0.2, 0.3, 0.4],
-                'Synthetic Score': [0.1, 0.2, 0.3, 0.4],
+                'Real Correlation': [0.1, 0.2, 0.3, 0.4],
+                'Synthetic Correlation': [0.1, 0.2, 0.3, 0.4],
             })
         )
 

--- a/tests/unit/reports/multi_table/test_multi_table_quality_report.py
+++ b/tests/unit/reports/multi_table/test_multi_table_quality_report.py
@@ -309,7 +309,7 @@ class TestQualityReport:
         Expect that the instance is passed to pickle.
 
         Input:
-        - filename
+        - filepath
 
         Side Effects:
         - ``pickle`` is called with the instance.
@@ -333,13 +333,13 @@ class TestQualityReport:
         Expect that the report's load method is called with the expected args.
 
         Input:
-        - filename
+        - filepath
 
         Output:
         - the loaded model
 
         Side Effects:
-        - Expect that ``pickle`` is called with the filename.
+        - Expect that ``pickle`` is called with the filepath.
         """
         # Setup
         open_mock = mock_open(read_data=pickle.dumps('test'))

--- a/tests/unit/reports/single_table/test_single_table_plot_utils.py
+++ b/tests/unit/reports/single_table/test_single_table_plot_utils.py
@@ -5,8 +5,8 @@ import numpy as np
 import pandas as pd
 
 from sdmetrics.reports.single_table.plot_utils import (
-    _get_column_shapes_data, _get_similarity_correlation_matrix, get_column_pairs_plot,
-    get_column_shapes_plot)
+    _get_column_shapes_data, _get_numerical_correlation_matrices,
+    _get_similarity_correlation_matrix, get_column_pairs_plot, get_column_shapes_plot)
 
 
 def test__get_column_shapes_data():
@@ -105,6 +105,55 @@ def test__get_similarity_correlation_matrix():
     )
 
     pd.testing.assert_frame_equal(out, expected)
+
+
+def test__get_numerical_correlation_matrices():
+    """Test the ``_get_numerical_correlation_matrices`` function.
+
+    Expect that the score breakdowns are converted into a real and synthetic numerical matrices.
+
+    Input:
+    - score breakdowns
+
+    Output:
+    - correlation matrix
+    """
+    # Setup
+    score_breakdowns = {
+        'CorrelationSimilarity': {
+            ('col1', 'col2'): {'score': 0.1, 'real': 0.1, 'synthetic': 0.4},
+            ('col1', 'col3'): {'score': 0.2, 'real': 0.2, 'synthetic': 0.5},
+            ('col2', 'col3'): {'score': 0.3, 'real': 0.3, 'synthetic': 0.6},
+        },
+        'METRIC2': {('col1', 'col3'): {'score': 0.2}},
+    }
+
+    # Run
+    (real_correlation, synthetic_correlation) = _get_numerical_correlation_matrices(
+        score_breakdowns)
+
+    # Assert
+    expected_real = pd.DataFrame(
+        [
+            [1, 0.1, 0.2],
+            [0.1, 1, 0.3],
+            [0.2, 0.3, 1],
+        ],
+        columns=['col1', 'col2', 'col3'],
+        index=['col1', 'col2', 'col3'],
+    )
+    expected_synthetic = pd.DataFrame(
+        [
+            [1, 0.4, 0.5],
+            [0.4, 1, 0.6],
+            [0.5, 0.6, 1],
+        ],
+        columns=['col1', 'col2', 'col3'],
+        index=['col1', 'col2', 'col3'],
+    )
+
+    pd.testing.assert_frame_equal(real_correlation, expected_real)
+    pd.testing.assert_frame_equal(synthetic_correlation, expected_synthetic)
 
 
 @patch('sdmetrics.reports.single_table.plot_utils.make_subplots')

--- a/tests/unit/reports/single_table/test_single_table_plot_utils.py
+++ b/tests/unit/reports/single_table/test_single_table_plot_utils.py
@@ -123,19 +123,12 @@ def test_get_column_pairs_plot(heatmap_mock, make_subplots_mock):
     """
     # Setup
     score_breakdowns = {
-        'METRIC1': {('col1', 'col2'): {'score': 0.1}, ('col2', 'col3'): {'score': 0.3}},
-        'METRIC2': {('col1', 'col3'): {'score': 0.2}},
+        'CorrelationSimilarity': {
+            ('col1', 'col2'): {'score': 0.1, 'real': 0.1, 'synthetic': 0.1},
+            ('col2', 'col3'): {'score': 0.3, 'real': 0.3, 'synthetic': 0.3},
+        },
+        'ContingencySimilarity': {('col1', 'col3'): {'score': 0.2}},
     }
-    real_correlation = pd.DataFrame(
-        [[1, 0.1, 0.1], [0.1, 1, 0.1], [0.1, 0.1, 1]],
-        columns=['col1', 'col2', 'col3'],
-        index=['col1', 'col2', 'col3'],
-    )
-    synthetic_correlation = pd.DataFrame(
-        [[1, 0.1, 0.1], [0.1, 1, 0.1], [0.1, 0.1, 1]],
-        columns=['col1', 'col2', 'col3'],
-        index=['col1', 'col2', 'col3'],
-    )
     mock_fig = Mock()
     make_subplots_mock.return_value = mock_fig
     mock_heatmap_1 = Mock()
@@ -144,7 +137,7 @@ def test_get_column_pairs_plot(heatmap_mock, make_subplots_mock):
     heatmap_mock.side_effect = [mock_heatmap_1, mock_heatmap_2, mock_heatmap_3]
 
     # Run
-    out = get_column_pairs_plot(score_breakdowns, real_correlation, synthetic_correlation)
+    out = get_column_pairs_plot(score_breakdowns)
 
     # Assert
     make_subplots_mock.assert_called_once()

--- a/tests/unit/reports/single_table/test_single_table_quality_report.py
+++ b/tests/unit/reports/single_table/test_single_table_quality_report.py
@@ -399,12 +399,8 @@ class TestQualityReport:
         pd.testing.assert_frame_equal(
             out,
             pd.DataFrame({
-                'Columns': [
-                    ('col1', 'col3'),
-                    ('col2', 'col4'),
-                    ('col1', 'col3'),
-                    ('col2', 'col4'),
-                ],
+                'Column 1': ['col1', 'col2', 'col1', 'col2'],
+                'Column 2': ['col3', 'col4', 'col3', 'col4'],
                 'Metric': [
                     'CorrelationSimilarity',
                     'CorrelationSimilarity',

--- a/tests/unit/reports/single_table/test_single_table_quality_report.py
+++ b/tests/unit/reports/single_table/test_single_table_quality_report.py
@@ -412,8 +412,8 @@ class TestQualityReport:
                     'ContingencySimilarity',
                 ],
                 'Quality Score': [0.1, 0.2, 0.3, 0.4],
-                'Real Score': [0.1, 0.2, 0.3, 0.4],
-                'Synthetic Score': [0.1, 0.2, 0.3, 0.4],
+                'Real Correlation': [0.1, 0.2, 0.3, 0.4],
+                'Synthetic Correlation': [0.1, 0.2, 0.3, 0.4],
             })
         )
 

--- a/tests/unit/reports/single_table/test_single_table_quality_report.py
+++ b/tests/unit/reports/single_table/test_single_table_quality_report.py
@@ -238,7 +238,7 @@ class TestQualityReport:
         Expect that the instance is passed to pickle.
 
         Input:
-        - filename
+        - filepath
 
         Side Effects:
         - ``pickle`` is called with the instance.
@@ -262,13 +262,13 @@ class TestQualityReport:
         Expect that the report's load method is called with the expected args.
 
         Input:
-        - filename
+        - filepath
 
         Output:
         - the loaded model
 
         Side Effects:
-        - Expect that ``pickle`` is called with the filename.
+        - Expect that ``pickle`` is called with the filepath.
         """
         # Setup
         open_mock = mock_open(read_data=pickle.dumps('test'))

--- a/tests/unit/reports/single_table/test_single_table_quality_report.py
+++ b/tests/unit/reports/single_table/test_single_table_quality_report.py
@@ -1,6 +1,7 @@
 import pickle
 from unittest.mock import Mock, mock_open, patch
 
+import numpy as np
 import pandas as pd
 
 from sdmetrics.reports.single_table import QualityReport
@@ -346,7 +347,8 @@ class TestQualityReport:
     def test_get_raw_result(self):
         """Test the ``get_raw_result`` method.
 
-        Expect that the raw result of the desired metric is returned.
+        Expect that the raw result of the desired metric is returned. Expect that null
+        scores are excluded.
 
         Input:
         - metric name
@@ -360,6 +362,7 @@ class TestQualityReport:
             'KSComplement': {
                 'col1': {'score': 0.1},
                 'col2': {'score': 0.2},
+                'col3': {'score': np.nan},
             },
         }
 

--- a/tests/unit/reports/single_table/test_single_table_quality_report.py
+++ b/tests/unit/reports/single_table/test_single_table_quality_report.py
@@ -367,10 +367,15 @@ class TestQualityReport:
         out = report.get_raw_result('KSComplement')
 
         # Assert
-        assert out == {
-            'metric': 'sdmetrics.single_table.multi_single_column.KSComplement',
-            'results': {
-                'col1': {'score': 0.1},
-                'col2': {'score': 0.2},
+        assert out == [
+            {
+                'metric': {
+                    'method': 'sdmetrics.single_table.multi_single_column.KSComplement',
+                    'parameters': {},
+                },
+                'results': {
+                    'col1': {'score': 0.1},
+                    'col2': {'score': 0.2},
+                }
             }
-        }
+        ]

--- a/tests/unit/reports/single_table/test_single_table_quality_report.py
+++ b/tests/unit/reports/single_table/test_single_table_quality_report.py
@@ -247,10 +247,6 @@ class TestQualityReport:
         report._metric_results['CorrelationSimilarity'] = {'score': 'test_score_1'}
         report._metric_results['ContingencySimilarity'] = {'score': 'test_score_2'}
         report._property_breakdown['Column Pair Trends'] = 0.78
-        mock_real_corr = Mock()
-        report._real_corr = mock_real_corr
-        mock_synth_corr = Mock()
-        report._synth_corr = mock_synth_corr
 
         # Run
         report.show_details('Column Pair Trends')
@@ -259,7 +255,7 @@ class TestQualityReport:
         get_plot_mock.assert_called_once_with({
             'CorrelationSimilarity': {'score': 'test_score_1'},
             'ContingencySimilarity': {'score': 'test_score_2'},
-        }, mock_real_corr, mock_synth_corr, 0.78)
+        }, 0.78)
 
     def test_get_details(self):
         """Test the ``get_details`` method.


### PR DESCRIPTION
Formatting updates:
- Update `get_raw_result` output formatting
- Filter out null scores from `get_raw_result` output
- In `plot_column` util, make NaNs a category
- Make plot titles consistent & update subplot titles
- Format overall score as a percentage, and fix formatting for NaN scores
- Separate column pair tuple into two columns in `get_details`
- Update heatmap colors

Functionality fixes:
- Fix duplicate key bug for Column Pair Trends
- Fix missing value inconsistencies for real and synthetic correlation plots
- Handle edge case in single-table QualityReport where one metric has no results.
- Handle edge case in multi-table QualityReport where there is only one table (no parent-child relationship results).
- Multi table QualityReport's `show_details` and `get_details` should filter parent-child relationships by table name

Functionality updates:
- sort column pair tuples in alphabetical order within each tuple