### PR TITLE
Address Diagnostic Report and metric edge cases

### DIFF
--- a/sdmetrics/reports/multi_table/diagnostic_report.py
+++ b/sdmetrics/reports/multi_table/diagnostic_report.py
@@ -59,7 +59,7 @@ class DiagnosticReport():
                 self._results['DANGER'].append(
                     DIAGNOSTIC_REPORT_RESULT_DETAILS[metric]['DANGER'])
 
-        out.write('DiagnosticResults:\n')
+        out.write('\nDiagnosticResults:\n')
         print_results_for_level(out, self._results, 'SUCCESS')
         print_results_for_level(out, self._results, 'WARNING')
         print_results_for_level(out, self._results, 'DANGER')
@@ -101,6 +101,7 @@ class DiagnosticReport():
             except IncomputableMetricError:
                 # Metric is not compatible with this dataset.
                 self._metric_results[metric_name] = {}
+                self._metric_averages[metric_name] = np.nan
 
         self._property_scores = {}
         for prop, metrics in self.METRICS.items():

--- a/sdmetrics/reports/single_table/diagnostic_report.py
+++ b/sdmetrics/reports/single_table/diagnostic_report.py
@@ -58,7 +58,7 @@ class DiagnosticReport():
                 self._results['DANGER'].append(
                     DIAGNOSTIC_REPORT_RESULT_DETAILS[metric]['DANGER'])
 
-        out.write('DiagnosticResults:\n')
+        out.write('\nDiagnosticResults:\n')
         print_results_for_level(out, self._results, 'SUCCESS')
         print_results_for_level(out, self._results, 'WARNING')
         print_results_for_level(out, self._results, 'DANGER')
@@ -91,6 +91,7 @@ class DiagnosticReport():
             except IncomputableMetricError:
                 # Metric is not compatible with this dataset.
                 self._metric_results[metric_name] = {}
+                self._metric_averages[metric_name] = np.nan
 
         self._property_scores = {}
         for prop, metrics in self.METRICS.items():

--- a/sdmetrics/reports/utils.py
+++ b/sdmetrics/reports/utils.py
@@ -19,43 +19,43 @@ DISCRETE_SDTYPES = ['categorical', 'boolean']
 DIAGNOSTIC_REPORT_RESULT_DETAILS = {
     'BoundaryAdherence': {
         'SUCCESS': (
-            '✓ The synthetic data general follows the min/max boundaries set by the real data'
+            'The synthetic data follows over 90% of the min/max boundaries set by the real data'
         ),
         'WARNING': (
-            '! More than 10% the synthetic data does not follow the min/max boundaries set by '
+            'More than 10% the synthetic data does not follow the min/max boundaries set by '
             'the real data'
         ),
         'DANGER': (
-            'x More than 50% the synthetic data does not follow the min/max boundaries set by '
+            'More than 50% the synthetic data does not follow the min/max boundaries set by '
             'the real data'
         ),
     },
     'CategoryCoverage': {
-        'SUCCESS': '✓ The synthetic data generally covers categories present in the real data',
+        'SUCCESS': 'The synthetic data covers over 90% of the categories present in the real data',
         'WARNING': (
-            '! The synthetic data is missing more than 10% of the categories present in the '
+            'The synthetic data is missing more than 10% of the categories present in the '
             'real data'
         ),
         'DANGER': (
-            'x The synthetic data is missing more than 50% of the categories present in the '
+            'The synthetic data is missing more than 50% of the categories present in the '
             'real data'
         ),
     },
     'NewRowSynthesis': {
-        'SUCCESS': '✓ The synthetic rows are generally not copies of the real data',
-        'WARNING': '! More than 10% of the synthetic rows are copies of the real data',
-        'DANGER': 'x More than 50% of the synthetic rows are copies of the real data',
+        'SUCCESS': 'Over 90% of the synthetic rows are not copies of the real data',
+        'WARNING': 'More than 10% of the synthetic rows are copies of the real data',
+        'DANGER': 'More than 50% of the synthetic rows are copies of the real data',
     },
     'RangeCoverage': {
         'SUCCESS': (
-            '✓ The synthetic data generally covers numerical ranges present in the real data'
+            'The synthetic data covers over 90% of the numerical ranges present in the real data'
         ),
         'WARNING': (
-            '! The synthetic data is missing more than 10% of the numerical ranges present in '
+            'The synthetic data is missing more than 10% of the numerical ranges present in '
             'the real data'
         ),
         'DANGER': (
-            'x The synthetic data is missing more than 50% of the numerical ranges present in '
+            'The synthetic data is missing more than 50% of the numerical ranges present in '
             'the real data'
         ),
     }
@@ -564,7 +564,9 @@ def print_results_for_level(out, results, level):
         level (string):
             The level to print results for.
     """
+    level_marks = {'SUCCESS': '✓', 'WARNING': '!', 'DANGER': 'x'}
+
     if len(results[level]) > 0:
         out.write(f'\n{level}:\n')
         for result in results[level]:
-            out.write(f'{result}\n')
+            out.write(f'{level_marks[level]} {result}\n')

--- a/sdmetrics/single_column/statistical/category_coverage.py
+++ b/sdmetrics/single_column/statistical/category_coverage.py
@@ -61,13 +61,14 @@ class CategoryCoverage(SingleColumnMetric):
         real_data = pd.Series(real_data).dropna()
         synthetic_data = pd.Series(synthetic_data).dropna()
 
-        real_data_value = real_data.nunique()
-        synthetic_data_value = synthetic_data.nunique()
+        real_data_values = set(real_data.value_counts().index)
+        synthetic_data_values = set(synthetic_data.value_counts().index)
+        synthetic_coverage = synthetic_data_values.intersection(real_data_values)
 
         return {
-            'score': synthetic_data_value / real_data_value,
-            'real': real_data_value,
-            'synthetic': synthetic_data_value,
+            'score': len(synthetic_coverage) / len(real_data_values),
+            'real': len(real_data_values),
+            'synthetic': len(synthetic_coverage),
         }
 
     @classmethod

--- a/sdmetrics/single_table/new_row_synthesis.py
+++ b/sdmetrics/single_table/new_row_synthesis.py
@@ -86,17 +86,17 @@ class NewRowSynthesis(SingleTableMetric):
             row_filter = []
             for field in real_data.columns:
                 if pd.isna(row[field]):
-                    field_filter = f'{field}.isnull()'
+                    field_filter = f'`{field}`.isnull()'
                 elif field in numerical_fields:
                     field_filter = (
-                        f'abs({field} - {row[field]}) <= '
+                        f'abs(`{field}` - {row[field]}) <= '
                         f'{abs(numerical_match_tolerance * row[field])}'
                     )
                 else:
                     if real_data[field].dtype == 'O':
-                        field_filter = f"{field} == '{row[field]}'"
+                        field_filter = f'`{field}` == {repr(row[field])}'
                     else:
-                        field_filter = f'{field} == {row[field]}'
+                        field_filter = f'`{field}` == {row[field]}'
 
                 row_filter.append(field_filter)
 

--- a/tests/unit/reports/single_table/test_single_table_diagnostic_report.py
+++ b/tests/unit/reports/single_table/test_single_table_diagnostic_report.py
@@ -1,9 +1,11 @@
 import pickle
 from unittest.mock import Mock, call, mock_open, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
+from sdmetrics.errors import IncomputableMetricError
 from sdmetrics.reports.single_table import DiagnosticReport
 
 
@@ -20,6 +22,7 @@ class TestDiagnosticReport:
         # Assert
         assert report._metric_results == {}
         assert report._metric_averages == {}
+        assert report._property_scores == {}
         assert report._results == {}
 
     def test_generate(self):
@@ -86,7 +89,7 @@ class TestDiagnosticReport:
         }
 
     def test_generate_with_errored_metric(self):
-        """Test the ``generate`` method when the is a metric that has an error.
+        """Test the ``generate`` method when a metric has an error.
 
         Expect that the single-table metrics are called. Expect that the results are computed
         without the error-ed out metric.
@@ -145,6 +148,65 @@ class TestDiagnosticReport:
             real_data, synthetic_data, metadata)
         boundary_adherence.compute_breakdown.assert_called_once_with(
             real_data, synthetic_data, metadata)
+
+    def test_generate_with_incomputable_metric_error(self):
+        """Test the ``generate`` method when a metric throws an error.
+
+        Expect that the error is caught and the score is set to None.
+        """
+        # Setup
+        real_data = pd.DataFrame({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']})
+        synthetic_data = pd.DataFrame({'col1': [2, 2, 3], 'col2': ['b', 'a', 'c']})
+        range_coverage = Mock()
+        range_coverage.__name__ = 'RangeCoverage'
+        range_coverage.compute_breakdown.return_value = {
+            'col1': {'score': 0.1},
+            'col2': {'score': 0.2},
+        }
+
+        category_coverage = Mock()
+        category_coverage.__name__ = 'CategoryCoverage'
+        category_coverage.compute_breakdown.return_value = {
+            'col1': {'score': 0.1},
+            'col2': {'score': 0.2},
+        }
+
+        new_row_synth = Mock()
+        new_row_synth.__name__ = 'NewRowSynthesis'
+        new_row_synth.compute_breakdown.side_effect = IncomputableMetricError()
+
+        boundary_adherence = Mock()
+        boundary_adherence.__name__ = 'BoundaryAdherence'
+        boundary_adherence.compute_breakdown.return_value = {
+            'col1': {'score': 0.1},
+            'col2': {'error': 'test error'},
+        }
+        metrics_mock = {
+            'Coverage': [range_coverage, category_coverage],
+            'Synthesis': [new_row_synth],
+            'Boundaries': [boundary_adherence],
+        }
+        metadata = {'fields': {'col1': {'type': 'numerical'}, 'col2': {'type': 'categorical'}}}
+
+        # Run
+        with patch.object(
+            DiagnosticReport,
+            'METRICS',
+            metrics_mock,
+        ):
+            report = DiagnosticReport()
+            report.generate(real_data, synthetic_data, metadata)
+
+        # Assert
+        range_coverage.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        category_coverage.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        new_row_synth.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        boundary_adherence.compute_breakdown.assert_called_once_with(
+            real_data, synthetic_data, metadata)
+        assert np.isnan(report._property_scores['Synthesis'])
 
     def test_get_results(self):
         """Test the ``get_results`` method.
@@ -324,7 +386,7 @@ class TestDiagnosticReport:
 
         # Assert
         mock_out.write.assert_has_calls([
-            call('DiagnosticResults:\n'),
+            call('\nDiagnosticResults:\n'),
             call('\nWARNING:\n'),
             call('! More than 10% the synthetic data does not follow the min/max boundaries '
                  'set by the real data\n'),

--- a/tests/unit/single_column/statistical/test_category_coverage.py
+++ b/tests/unit/single_column/statistical/test_category_coverage.py
@@ -31,6 +31,23 @@ class TestCategoryCoverage:
         # Assert
         assert result == {'score': 2 / 3, 'real': 3, 'synthetic': 2}
 
+    def test_compute_breakdown_missing_categories(self):
+        """Test the ``compute_breakdown`` method with missing categorical values.
+
+        Expect that the number of unique categories is computed for both real and synthetic data.
+        """
+        # Setup
+        real_data = pd.Series(['a', 'b', 'a', 'b', 'c'])
+        synthetic_data = pd.Series(['d', 'e', 'f', 'f', 'e'])
+
+        metric = CategoryCoverage()
+
+        # Run
+        result = metric.compute_breakdown(real_data, synthetic_data)
+
+        # Assert
+        assert result == {'score': 0, 'real': 3, 'synthetic': 0}
+
     def test_compute(self):
         """Test the ``compute`` method.
 

--- a/tests/unit/single_table/test_new_row_synthesis.py
+++ b/tests/unit/single_table/test_new_row_synthesis.py
@@ -45,6 +45,30 @@ class TestNewRowSynthesis:
         # Assert
         assert score == 0.8
 
+    def test_compute_breakdown_multi_line(self):
+        """Test the ``compute_breakdown`` method with a multi-line value.
+
+        Expect that the match is made correctly."""
+        # Setup
+        real_data = pd.DataFrame({
+            'col1': ['PSC 0481, Box 5945\nAPO AP 37588', 'Unit 9759 Box 8761\nDPO AE 97614'],
+        })
+        synthetic_data = pd.DataFrame({
+            'col1': ['PSC 0481, Box 5945\nAPO AP 37588', '9759 8761\nDPO AE 97614'],
+        })
+        metadata = {
+            'fields': {
+                'col1': {'type': 'categorical'},
+            },
+        }
+        metric = NewRowSynthesis()
+
+        # Run
+        score = metric.compute(real_data, synthetic_data, metadata)
+
+        # Assert
+        assert score == 0.5
+
     def test_compute_with_sample_size(self):
         """Test the ``compute`` method with a sample size.
 


### PR DESCRIPTION
Update Diagnostic Report
- Remove special characters from the `get_results` output
- Update print formatting and messages
- If metric is not applicable, set average metric score to `np.nan`

Update `NewRowSynthesis` metric
- Allow querying by values with new lines
- Allow querying by columns with spaces

Update `CategoryCoverage` metric
- Calculate the number of intersecting categories