### PR TITLE
Fix range coverage with nan data

### DIFF
--- a/sdmetrics/single_column/statistical/range_coverage.py
+++ b/sdmetrics/single_column/statistical/range_coverage.py
@@ -1,6 +1,7 @@
 """Range Coverage Metric."""
 
 import numpy as np
+import pandas as pd
 
 from sdmetrics.goal import Goal
 from sdmetrics.single_column.base import SingleColumnMetric
@@ -42,10 +43,16 @@ class RangeCoverage(SingleColumnMetric):
             float:
                 The range coverage of the synthetic data over the real data.
         """
-        min_r = min(real_data)
-        max_r = max(real_data)
-        min_s = min(synthetic_data)
-        max_s = max(synthetic_data)
+        if not isinstance(real_data, pd.Series):
+            real_data = pd.Series(real_data)
+
+        if not isinstance(synthetic_data, pd.Series):
+            synthetic_data = pd.Series(synthetic_data)
+
+        min_r = real_data.min()
+        max_r = real_data.max()
+        min_s = synthetic_data.min()
+        max_s = synthetic_data.max()
 
         if min_r == max_r:
             return np.nan

--- a/tests/unit/single_column/statistical/test_range_coverage.py
+++ b/tests/unit/single_column/statistical/test_range_coverage.py
@@ -56,6 +56,40 @@ class TestRangeCoverage:
         # Assert
         assert np.isnan(result)
 
+    def test_compute_with_nans(self):
+        """Test the ``compute`` method with NaN values in the input data.
+
+        Expect that the range coverage is returned.
+        """
+        # Setup
+        real_data = pd.Series([1, np.nan, 3, 4, 5])
+        synthetic_data = pd.Series([2, 3, 1, np.nan, 3])
+
+        metric = RangeCoverage()
+
+        # Run
+        result = metric.compute(real_data, synthetic_data)
+
+        # Assert
+        assert result == 0.5
+
+    def test_compute_with_list_input(self):
+        """Test the ``compute`` method with list input.
+
+        Expect that the range coverage is returned.
+        """
+        # Setup
+        real_data = [1, np.nan, 3, 4, 5]
+        synthetic_data = [2, 3, 1, np.nan, 3]
+
+        metric = RangeCoverage()
+
+        # Run
+        result = metric.compute(real_data, synthetic_data)
+
+        # Assert
+        assert result == 0.5
+
     @patch('sdmetrics.single_column.statistical.range_coverage.SingleColumnMetric.normalize')
     def test_normalize(self, normalize_mock):
         """Test the ``normalize`` method.


### PR DESCRIPTION
Resolves #255 

`RangeCoverage` metric was handling input data with null values incorrectly, and returning a metric result of `NaN`.