### PR TITLE
Update README.md to fix a bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ my_report = QualityReport.load(filepath='demo_data_quality_report.pkl')
 ```python
 # calculate whether the synthetic data respects the min/max bounds
 # set by the real data
-from sdmetrics.single_table import BoundaryAdherence
+from sdmetrics.single_column import BoundaryAdherence
 
 BoundaryAdherence.compute(
-    real_data[['start_date']],
-    synthetic_data[['start_date']]
+    real_data['start_date'],
+    synthetic_data['start_date']
 )
 ```
 ```

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ my_report = QualityReport.load(filepath='demo_data_quality_report.pkl')
 from sdmetrics.single_table import BoundaryAdherence
 
 BoundaryAdherence.compute(
-    real_data['start_date'],
-    synthetic_data['start_date']
+    real_data[['start_date']],
+    synthetic_data[['start_date']]
 )
 ```
 ```


### PR DESCRIPTION
BoundaryAdherence expects DataFrames for the real and synthetic dataframe arguments, currently it is receiving series due to accessing date_range with single square brackets instead of double square brackets.