### PR TITLE
Fix `ValueError` in `NewRowSynthesis` if size of `row_filter` exceeds 31

### DIFF
--- a/sdmetrics/single_table/new_row_synthesis.py
+++ b/sdmetrics/single_table/new_row_synthesis.py
@@ -108,9 +108,12 @@ class NewRowSynthesis(SingleTableMetric):
 
                 row_filter.append(field_filter)
 
+            engine = None
+            if len(row_filter) >= 32:  # Limit set by NPY_MAXARGS
+                engine = 'python'
             try:
-                matches = real_data.query(' and '.join(row_filter))
-            except TypeError:
+                matches = real_data.query(' and '.join(row_filter), engine=engine)
+            except (TypeError, ValueError):
                 if len(real_data) > 10000:
                     warnings.warn('Unable to optimize query. For better formance, set the '
                                   '`synthetic_sample_size` parameter or upgrade to Python 3.8')

--- a/sdmetrics/single_table/new_row_synthesis.py
+++ b/sdmetrics/single_table/new_row_synthesis.py
@@ -113,7 +113,7 @@ class NewRowSynthesis(SingleTableMetric):
                 engine = 'python'
             try:
                 matches = real_data.query(' and '.join(row_filter), engine=engine)
-            except (TypeError, ValueError):
+            except TypeError:
                 if len(real_data) > 10000:
                     warnings.warn('Unable to optimize query. For better formance, set the '
                                   '`synthetic_sample_size` parameter or upgrade to Python 3.8')

--- a/tests/unit/single_table/test_new_row_synthesis.py
+++ b/tests/unit/single_table/test_new_row_synthesis.py
@@ -144,6 +144,32 @@ class TestNewRowSynthesis:
             'synthetic data rows (5). Proceeding without sampling.'
         )
 
+    def test_compute_with_many_columns(self):
+        """Test the ``compute`` method with more than 32 columns.
+
+           Expect that the new row synthesis is returned.
+        """
+        # Setup
+        num_cols = 32
+        real_data = pd.DataFrame({
+            f'col{i}': list(np.random.uniform(low=0, high=10, size=100)) for i in range(num_cols)
+        })
+        synthetic_data = pd.DataFrame({
+            f'col{i}': list(np.random.uniform(low=0, high=10, size=100)) for i in range(num_cols)
+        })
+        metadata = {
+            'fields': {
+                f'col{i}': {'type': 'numerical', 'subtype': 'float'} for i in range(num_cols)
+            },
+        }
+        metric = NewRowSynthesis()
+
+        # Run
+        score = metric.compute(real_data, synthetic_data, metadata)
+
+        # Assert
+        assert score == 1
+
     @patch('sdmetrics.single_table.new_row_synthesis.SingleTableMetric.normalize')
     def test_normalize(self, normalize_mock):
         """Test the ``normalize`` method.

--- a/tests/unit/single_table/test_new_row_synthesis.py
+++ b/tests/unit/single_table/test_new_row_synthesis.py
@@ -147,7 +147,7 @@ class TestNewRowSynthesis:
     def test_compute_with_many_columns(self):
         """Test the ``compute`` method with more than 32 columns.
 
-           Expect that the new row synthesis is returned.
+        Expect that the new row synthesis is returned.
         """
         # Setup
         num_cols = 32


### PR DESCRIPTION
Resolve #307 

Set the query engine to `'python'` if more than 31 `row_filter`s are specified. Trying to use the default `numexpr` will result in a `ValueError` or `Memory` error if more than 31 `row_filter`s are provided, probably due to `numpy` limiting `NPY_MAXARGS=32`.