### PR TITLE
Update `ParentChildDetectionMetric _denormalize` merge type

### DIFF
--- a/sdmetrics/multi_table/detection/parent_child.py
+++ b/sdmetrics/multi_table/detection/parent_child.py
@@ -55,7 +55,7 @@ class ParentChildDetectionMetric(DetectionMetric,
 
         flat = data[parent_table].set_index(parent_key).merge(
             data[child_table].set_index(child_key),
-            how='outer',
+            how='right',
             left_index=True,
             right_index=True,
         ).reset_index(drop=True)


### PR DESCRIPTION
Resolve #328.

A note: by changing the merge from `outer` to `right`, we will be ignoring all the parent rows which do not have a corresponding child, e.g. if the child table foreign keys only cover 10% of the parent table primary keys, then 90% of the data in the parent table will be ignored. Since `_denormalize` is used to compute the similarity between real and synthetic data, the majority of the data will not be evaluated at all.

That is to say, this change will make `ParentChildDetectionMetric` evaluate **only** the matching rows, and anything else will be ignored. 