### PR TITLE
Issue 355 column shape property

### DIFF
--- a/sdmetrics/reports/single_table/_properties/__init__.py
+++ b/sdmetrics/reports/single_table/_properties/__init__.py
@@ -1,7 +1,9 @@
 """Single table properties for sdmetrics."""
 
 from sdmetrics.reports.single_table._properties.base import BaseSingleTableProperty
+from sdmetrics.reports.single_table._properties.column_shapes import ColumnShapes
 
 __all__ = [
-    'BaseSingleTableProperty'
+    'BaseSingleTableProperty',
+    'ColumnShapes',
 ]

--- a/sdmetrics/reports/single_table/_properties/base.py
+++ b/sdmetrics/reports/single_table/_properties/base.py
@@ -1,6 +1,9 @@
 """Single table base property class."""
-from sdmetrics.reports.utils import validate_single_table_inputs
 import pandas as pd
+from tqdm.auto import tqdm
+
+from sdmetrics.reports.utils import validate_single_table_inputs
+
 
 class BaseSingleTableProperty():
     """Base class for single table properties.
@@ -11,18 +14,18 @@ class BaseSingleTableProperty():
 
     _details = None
 
-    def _average_scores(self):
+    def _compute_average(self):
         """Average the scores for each column."""
-        if not isinstance(self._details, pd.DataFrame) or "Score" not in self._details.columns:
+        if not isinstance(self._details, pd.DataFrame) or 'Score' not in self._details.columns:
             raise ValueError("The property details must be a DataFrame with a 'Score' column.")
 
-        return self._details["Score"].mean(ignore_na=True)
+        return round(self._details['Score'].mean(), 3)
 
-    def _get_score_dataframe(self, real_data, synthetic_data, metadata, progress_bar):
+    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm):
         """Get the average score for the property on the data."""
         raise NotImplementedError()
 
-    def get_score(self, real_data, synthetic_data, metadata, progress_bar):
+    def get_score(self, real_data, synthetic_data, metadata, progress_bar=tqdm):
         """Get the average score for the property on the data.
 
         Args:
@@ -40,8 +43,8 @@ class BaseSingleTableProperty():
                 The average score for the property.
         """
         validate_single_table_inputs(real_data, synthetic_data, metadata)
-        self._details = self._get_score_dataframe(real_data, synthetic_data, metadata, progress_bar)
-        return self._average_scores() 
+        self._details = self._generate_details(real_data, synthetic_data, metadata, progress_bar)
+        return self._compute_average()
 
     def get_visualization(self):
         """Return a visualization for each score in the property.

--- a/sdmetrics/reports/single_table/_properties/base.py
+++ b/sdmetrics/reports/single_table/_properties/base.py
@@ -1,6 +1,5 @@
 """Single table base property class."""
 import pandas as pd
-import tqdm
 
 
 class BaseSingleTableProperty():
@@ -19,7 +18,7 @@ class BaseSingleTableProperty():
 
         return round(self._details['Score'].mean(), 3)
 
-    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm.tqdm):
+    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=None):
         """Generate the _details dataframe for the property."""
         raise NotImplementedError()
 
@@ -33,7 +32,7 @@ class BaseSingleTableProperty():
                 The synthetic data.
             metadata (dict):
                 The metadata, which contains each column's data type as well as relationships.
-            progress_bar (tqdm.tqdm, optional):
+            progress_bar (tqdm.tqdm or None):
                 The progress bar object. Defaults to None.
 
         Returns:

--- a/sdmetrics/reports/single_table/_properties/base.py
+++ b/sdmetrics/reports/single_table/_properties/base.py
@@ -22,7 +22,7 @@ class BaseSingleTableProperty():
         return round(self._details['Score'].mean(), 3)
 
     def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm.tqdm):
-        """Get the average score for the property on the data."""
+        """Generate the _details dataframe for the property."""
         raise NotImplementedError()
 
     def get_score(self, real_data, synthetic_data, metadata, progress_bar=tqdm.tqdm):

--- a/sdmetrics/reports/single_table/_properties/base.py
+++ b/sdmetrics/reports/single_table/_properties/base.py
@@ -1,6 +1,6 @@
 """Single table base property class."""
 import pandas as pd
-from tqdm.auto import tqdm
+import tqdm
 
 from sdmetrics.reports.utils import validate_single_table_inputs
 
@@ -21,11 +21,11 @@ class BaseSingleTableProperty():
 
         return round(self._details['Score'].mean(), 3)
 
-    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm):
+    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm.tqdm):
         """Get the average score for the property on the data."""
         raise NotImplementedError()
 
-    def get_score(self, real_data, synthetic_data, metadata, progress_bar=tqdm):
+    def get_score(self, real_data, synthetic_data, metadata, progress_bar=tqdm.tqdm):
         """Get the average score for the property on the data.
 
         Args:

--- a/sdmetrics/reports/single_table/_properties/base.py
+++ b/sdmetrics/reports/single_table/_properties/base.py
@@ -2,8 +2,6 @@
 import pandas as pd
 import tqdm
 
-from sdmetrics.reports.utils import validate_single_table_inputs
-
 
 class BaseSingleTableProperty():
     """Base class for single table properties.
@@ -25,7 +23,7 @@ class BaseSingleTableProperty():
         """Generate the _details dataframe for the property."""
         raise NotImplementedError()
 
-    def get_score(self, real_data, synthetic_data, metadata, progress_bar=tqdm.tqdm):
+    def get_score(self, real_data, synthetic_data, metadata, progress_bar=None):
         """Get the average score for the property on the data.
 
         Args:
@@ -35,14 +33,13 @@ class BaseSingleTableProperty():
                 The synthetic data.
             metadata (dict):
                 The metadata, which contains each column's data type as well as relationships.
-            progress_bar (tqdm.tqdm):
-                The progress bar object.
+            progress_bar (tqdm.tqdm, optional):
+                The progress bar object. Defaults to None.
 
         Returns:
             float:
                 The average score for the property.
         """
-        validate_single_table_inputs(real_data, synthetic_data, metadata)
         self._details = self._generate_details(real_data, synthetic_data, metadata, progress_bar)
         return self._compute_average()
 

--- a/sdmetrics/reports/single_table/_properties/base.py
+++ b/sdmetrics/reports/single_table/_properties/base.py
@@ -1,5 +1,6 @@
 """Single table base property class."""
-
+from sdmetrics.reports.utils import validate_single_table_inputs
+import pandas as pd
 
 class BaseSingleTableProperty():
     """Base class for single table properties.
@@ -9,6 +10,17 @@ class BaseSingleTableProperty():
     """
 
     _details = None
+
+    def _average_scores(self):
+        """Average the scores for each column."""
+        if not isinstance(self._details, pd.DataFrame) or "Score" not in self._details.columns:
+            raise ValueError("The property details must be a DataFrame with a 'Score' column.")
+
+        return self._details["Score"].mean(ignore_na=True)
+
+    def _get_score_dataframe(self, real_data, synthetic_data, metadata, progress_bar):
+        """Get the average score for the property on the data."""
+        raise NotImplementedError()
 
     def get_score(self, real_data, synthetic_data, metadata, progress_bar):
         """Get the average score for the property on the data.
@@ -27,7 +39,9 @@ class BaseSingleTableProperty():
             float:
                 The average score for the property.
         """
-        raise NotImplementedError()
+        validate_single_table_inputs(real_data, synthetic_data, metadata)
+        self._details = self._get_score_dataframe(real_data, synthetic_data, metadata, progress_bar)
+        return self._average_scores() 
 
     def get_visualization(self):
         """Return a visualization for each score in the property.

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -1,13 +1,17 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+from tqdm.auto import tqdm
+
 from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
 from sdmetrics.single_column.statistical.kscomplement import KSComplement
 from sdmetrics.single_column.statistical.tv_complement import TVComplement
-import pandas as pd
-import numpy as np
-import plotly.express as px
 
 
 class ColumnShapes(BaseSingleTableProperty):
-    
+    """Column Shapes property class for single table."""
 
     metrics = [KSComplement, TVComplement]
     _sdtype_to_metric = {
@@ -17,27 +21,42 @@ class ColumnShapes(BaseSingleTableProperty):
         'boolean': TVComplement
     }
 
-    def _get_score(self, real_data, synthetic_data, metadata, progress_bar):
-        
+    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm):
+        """Generate the _details dataframe for the column shapes property.
+
+        Args:
+            real_data (pandas.DataFrame):
+                The real data
+            synthetic_data (pandas.DataFrame):
+                The synthetic data
+            metadata (dict):
+                The metadata of the table
+            progress_bar:
+                The progress bar to use. Defaults to tqdm.
+        """
         column_names, metric_names, scores = [], [], []
         for column_name in progress_bar(metadata['columns']):
-            sdtype = metadata[column_name]['sdtype']
+            sdtype = metadata['columns'][column_name]['sdtype']
             try:
                 if sdtype in self._sdtype_to_metric:
                     metric = self._sdtype_to_metric[sdtype]
-                    column_score = metric.compute(real_data[column_name], synthetic_data[column_name])
+                    column_score = metric.compute(
+                        real_data[column_name], synthetic_data[column_name]
+                    )
                 else:
                     continue
 
             except Exception as e:
-                    column_score = np.nan
-                    Warning("Unable to compute Column Shape for column <name>. " + 
-                            "Encountered Error: type(e).__name__ e")
-    
+                column_score = np.nan
+                warnings.warn(
+                        f"Unable to compute Column Shape for column '{column_name}'. "
+                        f'Encountered Error: {type(e).__name__} {e}'
+                )
+
             column_names.append(column_name)
             metric_names.append(metric.__name__)
             scores.append(column_score)
-    
+
         result = pd.DataFrame({
             'Column name': column_names,
             'Metric': metric_names,
@@ -52,15 +71,14 @@ class ColumnShapes(BaseSingleTableProperty):
         Returns:
             plotly.graph_objects._figure.Figure
         """
-        average_score = self._average_scores()
-        data = self._details
-    
+        average_score = self._compute_average()
+
         fig = px.bar(
-            data,
+            self._details,
             x='Column name',
             y='Score',
-            title=f'Data Quality: Column Shapes (Average Score={round(average_score, 2)})',
-            category_orders={'group': data['Column Name']},
+            title=f'Data Quality: Column Shapes (Average Score={average_score})',
+            category_orders={'group': self._details['Column name']},
             color='Metric',
             color_discrete_map={
                 'KSComplement': '#000036',
@@ -68,11 +86,11 @@ class ColumnShapes(BaseSingleTableProperty):
             },
             pattern_shape='Metric',
             pattern_shape_sequence=['', '/'],
-            hover_name='Column Name',
+            hover_name='Column name',
             hover_data={
-                'Column Name': False,
+                'Column name': False,
                 'Metric': True,
-                'Quality Score': True,
+                'Score': True,
             },
         )
 

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -1,13 +1,9 @@
-import logging
-
 import numpy as np
 import pandas as pd
 import plotly.express as px
 
 from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
 from sdmetrics.single_column import KSComplement, TVComplement
-
-LOGGER = logging.getLogger(__name__)
 
 
 class ColumnShapes(BaseSingleTableProperty):
@@ -57,7 +53,6 @@ class ColumnShapes(BaseSingleTableProperty):
             except Exception as e:
                 column_score = np.nan
                 error_message = f'Error: {type(e).__name__} {e}'
-                LOGGER.debug(error_message)
             finally:
                 if progress_bar:
                     progress_bar.update()

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -67,9 +67,6 @@ class ColumnShapes(BaseSingleTableProperty):
             scores.append(column_score)
             error_messages.append(error_message)
 
-        if progress_bar:
-            progress_bar.close()
-
         result = pd.DataFrame({
             'Column': column_names,
             'Metric': metric_names,

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import plotly.express as px
-from tqdm.auto import tqdm
+import tqdm
 
 from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
 from sdmetrics.single_column.statistical.kscomplement import KSComplement
@@ -21,7 +21,7 @@ class ColumnShapes(BaseSingleTableProperty):
         'boolean': TVComplement
     }
 
-    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm):
+    def _generate_details(self, real_data, synthetic_data, metadata, progress_bar=tqdm.tqdm):
         """Generate the _details dataframe for the column shapes property.
 
         Args:

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -35,7 +35,7 @@ class ColumnShapes(BaseSingleTableProperty):
                 The synthetic data
             metadata (dict):
                 The metadata of the table
-            progress_bar:
+            progress_bar (tqdm.tqdm or None):
                 The progress bar to use. Defaults to tqdm.
         """
         column_names, metric_names, scores = [], [], []

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -1,0 +1,45 @@
+from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
+from sdmetrics.single_column.statistical.kscomplement import KSComplement
+from sdmetrics.single_column.statistical.tv_complement import TVComplement
+import pandas as pd
+import numpy as np
+
+class ColumnShapes(BaseSingleTableProperty):
+    
+
+    metrics = [KSComplement, TVComplement]
+    _sdtype_to_metric = {
+        'numerical': KSComplement,
+        'datetime': KSComplement,
+        'categorical': TVComplement,
+        'boolean': TVComplement
+    }
+
+    def _get_score(self, real_data, synthetic_data, metadata, progress_bar):
+        
+        column_names, metric_names, scores = [], [], []
+        for column_name in progress_bar(metadata['columns']):
+            sdtype = metadata[column_name]['sdtype']
+            try:
+                if sdtype in self._sdtype_to_metric:
+                    metric = self._sdtype_to_metric[sdtype]
+                    column_score = metric.compute(real_data[column_name], synthetic_data[column_name])
+                else:
+                    continue
+
+            except Exception as e:
+                    column_score = np.nan
+                    Warning("Unable to compute Column Shape for column <name>. " + 
+                            "Encountered Error: type(e).__name__ e")
+    
+            column_names.append(column_name)
+            metric_names.append(metric.__name__)
+            scores.append(column_score)
+    
+        result = pd.DataFrame({
+            'Column': column_names,
+            'Metric': metric_names,
+            'Score': scores,
+        })
+
+        return result

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -11,7 +11,14 @@ from sdmetrics.single_column.statistical.tv_complement import TVComplement
 
 
 class ColumnShapes(BaseSingleTableProperty):
-    """Column Shapes property class for single table."""
+    """Column Shapes property class for single table.
+
+    This property assesses the shape similarity between the real and synthetic data.
+    A metric score is computed column-wise and the final score is the average over all columns.
+    The KSComplement metric is used for numerical and datetime columns while the TVComplement
+    is used for categorical and boolean columns.
+    The other column types are ignored by this property.
+    """
 
     metrics = [KSComplement, TVComplement]
     _sdtype_to_metric = {

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -5,8 +5,7 @@ import pandas as pd
 import plotly.express as px
 
 from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
-from sdmetrics.single_column.statistical.kscomplement import KSComplement
-from sdmetrics.single_column.statistical.tv_complement import TVComplement
+from sdmetrics.single_column import KSComplement, TVComplement
 
 
 class ColumnShapes(BaseSingleTableProperty):

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -3,6 +3,8 @@ from sdmetrics.single_column.statistical.kscomplement import KSComplement
 from sdmetrics.single_column.statistical.tv_complement import TVComplement
 import pandas as pd
 import numpy as np
+import plotly.express as px
+
 
 class ColumnShapes(BaseSingleTableProperty):
     
@@ -37,9 +39,49 @@ class ColumnShapes(BaseSingleTableProperty):
             scores.append(column_score)
     
         result = pd.DataFrame({
-            'Column': column_names,
+            'Column name': column_names,
             'Metric': metric_names,
             'Score': scores,
         })
 
         return result
+
+    def get_visualization(self):
+        """Create a plot to show the column shape scores.
+
+        Returns:
+            plotly.graph_objects._figure.Figure
+        """
+        average_score = self._average_scores()
+        data = self._details
+    
+        fig = px.bar(
+            data,
+            x='Column name',
+            y='Score',
+            title=f'Data Quality: Column Shapes (Average Score={round(average_score, 2)})',
+            category_orders={'group': data['Column Name']},
+            color='Metric',
+            color_discrete_map={
+                'KSComplement': '#000036',
+                'TVComplement': '#03AFF1',
+            },
+            pattern_shape='Metric',
+            pattern_shape_sequence=['', '/'],
+            hover_name='Column Name',
+            hover_data={
+                'Column Name': False,
+                'Metric': True,
+                'Quality Score': True,
+            },
+        )
+
+        fig.update_yaxes(range=[0, 1])
+
+        fig.update_layout(
+            xaxis_categoryorder='total ascending',
+            plot_bgcolor='#F5F5F8',
+            margin={'t': 150},
+        )
+
+        return fig

--- a/sdmetrics/reports/single_table/_properties/column_shapes.py
+++ b/sdmetrics/reports/single_table/_properties/column_shapes.py
@@ -1,9 +1,13 @@
+import logging
+
 import numpy as np
 import pandas as pd
 import plotly.express as px
 
 from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
 from sdmetrics.single_column import KSComplement, TVComplement
+
+LOGGER = logging.getLogger(__name__)
 
 
 class ColumnShapes(BaseSingleTableProperty):
@@ -52,9 +56,8 @@ class ColumnShapes(BaseSingleTableProperty):
 
             except Exception as e:
                 column_score = np.nan
-                error_message = (
-                        f'Error: {type(e).__name__} {e}'
-                )
+                error_message = f'Error: {type(e).__name__} {e}'
+                LOGGER.debug(error_message)
             finally:
                 if progress_bar:
                     progress_bar.update()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "scipy>=1.5.4,<2;python_version<'3.10'",
     "scipy>=1.9.2,<2;python_version>='3.10'",
     'copulas>=0.9.0,<0.10',
-    'tqdm>=4.26,<5',
+    'tqdm>=4.15,<5',
     'plotly>=5.10.0,<6',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "scipy>=1.5.4,<2;python_version<'3.10'",
     "scipy>=1.9.2,<2;python_version>='3.10'",
     'copulas>=0.9.0,<0.10',
-    'tqdm>=4.15,<5',
+    'tqdm>=4.26,<5',
     'plotly>=5.10.0,<6',
 ]
 

--- a/tests/integration/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/integration/reports/single_table/_properties/test_column_shapes.py
@@ -1,0 +1,76 @@
+import json
+import re
+
+import pandas as pd
+
+from sdmetrics.reports.single_table._properties.column_shapes import ColumnShapes
+
+
+class TestColumnShapes:
+
+    def test_get_score(self):
+        # Setup
+        real_data = pd.read_csv('sdmetrics/demos/single_table/real.csv')
+        synthetic_data = pd.read_csv('sdmetrics/demos/single_table/synthetic.csv')
+        with open('sdmetrics/demos/single_table/metadata.json', 'r') as f:
+            metadata = json.load(f)
+
+        # Run
+        column_shape_property = ColumnShapes()
+        score = column_shape_property.get_score(real_data, synthetic_data, metadata)
+
+        # Assert
+        expected_details_dict = {
+            'Column name': [
+                'start_date', 'end_date', 'salary', 'duration', 'high_perc', 'high_spec',
+                'mba_spec', 'second_perc', 'gender', 'degree_perc', 'placed', 'experience_years',
+                'employability_perc', 'mba_perc', 'work_experience', 'degree_type'
+            ],
+            'Metric': [
+                'KSComplement', 'KSComplement', 'KSComplement', 'KSComplement', 'KSComplement',
+                'TVComplement', 'TVComplement', 'KSComplement', 'TVComplement', 'KSComplement',
+                'TVComplement', 'KSComplement', 'KSComplement', 'KSComplement', 'TVComplement',
+                'TVComplement'
+            ],
+            'Score': [
+                0.701107, 0.768919, 0.869155, 0.826051, 0.553488, 0.902326, 0.995349, 0.627907,
+                0.939535, 0.627907, 0.916279, 0.800000, 0.781395, 0.841860, 0.972093, 0.925581
+            ]
+        }
+        expected_details = pd.DataFrame(expected_details_dict)
+        pd.testing.assert_frame_equal(column_shape_property._details, expected_details)
+        assert score == 0.816
+
+    def test_get_score_warnings(self, recwarn):
+        """Test the ``get_score`` method when the metrics are raising erros for some columns."""
+        # Setup
+        real_data = pd.read_csv('sdmetrics/demos/single_table/real.csv')
+        synthetic_data = pd.read_csv('sdmetrics/demos/single_table/synthetic.csv')
+        with open('sdmetrics/demos/single_table/metadata.json', 'r') as f:
+            metadata = json.load(f)
+
+        real_data['start_date'].iloc[0] = 0
+        real_data['employability_perc'].iloc[2] = 'a'
+
+        # Run
+        column_shape_property = ColumnShapes()
+
+        expected_message_1 = re.escape(
+            "Unable to compute Column Shape for column 'start_date'. "
+            "Encountered Error: TypeError '<' not supported between instances of 'str' and 'int'"
+        )
+        expected_message_2 = re.escape(
+            "Unable to compute Column Shape for column 'employability_perc'. "
+            "Encountered Error: TypeError '<' not supported between instances of 'str' and 'float'"
+        )
+
+        score = column_shape_property.get_score(real_data, synthetic_data, metadata)
+
+        # Assert
+        assert re.match(expected_message_1, str(recwarn[0].message))
+        assert re.match(expected_message_2, str(recwarn[1].message))
+
+        details = column_shape_property._details
+        column_names_nan = list(details.loc[pd.isna(details['Score'])]['Column name'])
+        assert column_names_nan == ['start_date', 'employability_perc']
+        assert score == 0.826

--- a/tests/integration/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/integration/reports/single_table/_properties/test_column_shapes.py
@@ -1,8 +1,7 @@
 import pandas as pd
 
 from sdmetrics.demos import load_demo
-from sdmetrics.reports.single_table import QualityReport
-from sdmetrics.reports.single_table._properties.column_shapes import ColumnShapes
+from sdmetrics.reports.single_table._properties import ColumnShapes
 
 
 class TestColumnShapes:
@@ -67,24 +66,3 @@ class TestColumnShapes:
         assert error_messages[0] == expected_message_1
         assert error_messages[1] == expected_message_2
         assert score == 0.826
-
-    def test__generate_details_end_to_end(self):
-        # Setup
-        real_data, synthetic_data, metadata = load_demo('single_table')
-        column_shape_property = ColumnShapes()
-        quality_report = QualityReport()
-        quality_report.generate(real_data, synthetic_data, metadata)
-        details_quality_report = quality_report.get_details(property_name='Column Shapes')
-        details_quality_report = details_quality_report.rename(columns={'Quality Score': 'Score'})
-
-        # Run
-        column_shape_property.get_score(real_data, synthetic_data, metadata)
-
-        # Assert
-        details_column_shape = column_shape_property._details
-        details_column_shape = details_column_shape.sort_values('Score').reset_index(drop=True)
-        details_quality_report = details_quality_report.sort_values('Score').reset_index(drop=True)
-
-        pd.testing.assert_frame_equal(
-            details_column_shape, details_quality_report
-        )

--- a/tests/integration/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/integration/reports/single_table/_properties/test_column_shapes.py
@@ -21,7 +21,7 @@ class TestColumnShapes:
 
         # Assert
         expected_details_dict = {
-            'Column name': [
+            'Column': [
                 'start_date', 'end_date', 'salary', 'duration', 'high_perc', 'high_spec',
                 'mba_spec', 'second_perc', 'gender', 'degree_perc', 'placed', 'experience_years',
                 'employability_perc', 'mba_perc', 'work_experience', 'degree_type'
@@ -71,6 +71,6 @@ class TestColumnShapes:
         assert re.match(expected_message_2, str(recwarn[1].message))
 
         details = column_shape_property._details
-        column_names_nan = list(details.loc[pd.isna(details['Score'])]['Column name'])
+        column_names_nan = list(details.loc[pd.isna(details['Score'])]['Column'])
         assert column_names_nan == ['start_date', 'employability_perc']
         assert score == 0.826

--- a/tests/integration/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/integration/reports/single_table/_properties/test_column_shapes.py
@@ -1,5 +1,3 @@
-import re
-
 import pandas as pd
 
 from sdmetrics.demos import load_demo
@@ -38,8 +36,8 @@ class TestColumnShapes:
         pd.testing.assert_frame_equal(column_shape_property._details, expected_details)
         assert score == 0.816
 
-    def test_get_score_warnings(self, recwarn):
-        """Test the ``get_score`` method when the metrics are raising erros for some columns."""
+    def test_get_score_warnings(self):
+        """Test the ``get_score`` method when the metrics are raising errors for some columns."""
         # Setup
         real_data, synthetic_data, metadata = load_demo('single_table')
 
@@ -49,22 +47,22 @@ class TestColumnShapes:
         # Run
         column_shape_property = ColumnShapes()
 
-        expected_message_1 = re.escape(
-            "Unable to compute Column Shape for column 'start_date'. Encountered Error:"
-            " TypeError '<' not supported between instances of 'Timestamp' and 'int'"
+        expected_message_1 = (
+            "Error: TypeError '<' not supported between instances of 'Timestamp' and 'int'"
         )
-        expected_message_2 = re.escape(
-            "Unable to compute Column Shape for column 'employability_perc'. "
-            "Encountered Error: TypeError '<' not supported between instances of 'str' and 'float'"
+        expected_message_2 = (
+            "Error: TypeError '<' not supported between instances of 'str' and 'float'"
         )
 
         score = column_shape_property.get_score(real_data, synthetic_data, metadata)
 
         # Assert
-        assert re.match(expected_message_1, str(recwarn[0].message))
-        assert re.match(expected_message_2, str(recwarn[1].message))
 
         details = column_shape_property._details
-        column_names_nan = list(details.loc[pd.isna(details['Score'])]['Column'])
+        details_nan = details.loc[pd.isna(details['Score'])]
+        column_names_nan = details_nan['Column'].tolist()
+        error_messages = details_nan['Error'].tolist()
         assert column_names_nan == ['start_date', 'employability_perc']
+        assert error_messages[0] == expected_message_1
+        assert error_messages[1] == expected_message_2
         assert score == 0.826

--- a/tests/integration/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/integration/reports/single_table/_properties/test_column_shapes.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from sdmetrics.demos import load_demo
+from sdmetrics.reports.single_table import QualityReport
 from sdmetrics.reports.single_table._properties.column_shapes import ColumnShapes
 
 
@@ -36,7 +37,7 @@ class TestColumnShapes:
         pd.testing.assert_frame_equal(column_shape_property._details, expected_details)
         assert score == 0.816
 
-    def test_get_score_warnings(self):
+    def test_get_score_errors(self):
         """Test the ``get_score`` method when the metrics are raising errors for some columns."""
         # Setup
         real_data, synthetic_data, metadata = load_demo('single_table')
@@ -66,3 +67,24 @@ class TestColumnShapes:
         assert error_messages[0] == expected_message_1
         assert error_messages[1] == expected_message_2
         assert score == 0.826
+
+    def test__generate_details_end_to_end(self):
+        # Setup
+        real_data, synthetic_data, metadata = load_demo('single_table')
+        column_shape_property = ColumnShapes()
+        quality_report = QualityReport()
+        quality_report.generate(real_data, synthetic_data, metadata)
+        details_quality_report = quality_report.get_details(property_name='Column Shapes')
+        details_quality_report = details_quality_report.rename(columns={'Quality Score': 'Score'})
+
+        # Run
+        column_shape_property.get_score(real_data, synthetic_data, metadata)
+
+        # Assert
+        details_column_shape = column_shape_property._details
+        details_column_shape = details_column_shape.sort_values('Score').reset_index(drop=True)
+        details_quality_report = details_quality_report.sort_values('Score').reset_index(drop=True)
+
+        pd.testing.assert_frame_equal(
+            details_column_shape, details_quality_report
+        )

--- a/tests/integration/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/integration/reports/single_table/_properties/test_column_shapes.py
@@ -1,8 +1,8 @@
-import json
 import re
 
 import pandas as pd
 
+from sdmetrics.demos import load_demo
 from sdmetrics.reports.single_table._properties.column_shapes import ColumnShapes
 
 
@@ -10,10 +10,7 @@ class TestColumnShapes:
 
     def test_get_score(self):
         # Setup
-        real_data = pd.read_csv('sdmetrics/demos/single_table/real.csv')
-        synthetic_data = pd.read_csv('sdmetrics/demos/single_table/synthetic.csv')
-        with open('sdmetrics/demos/single_table/metadata.json', 'r') as f:
-            metadata = json.load(f)
+        real_data, synthetic_data, metadata = load_demo('single_table')
 
         # Run
         column_shape_property = ColumnShapes()
@@ -44,10 +41,7 @@ class TestColumnShapes:
     def test_get_score_warnings(self, recwarn):
         """Test the ``get_score`` method when the metrics are raising erros for some columns."""
         # Setup
-        real_data = pd.read_csv('sdmetrics/demos/single_table/real.csv')
-        synthetic_data = pd.read_csv('sdmetrics/demos/single_table/synthetic.csv')
-        with open('sdmetrics/demos/single_table/metadata.json', 'r') as f:
-            metadata = json.load(f)
+        real_data, synthetic_data, metadata = load_demo('single_table')
 
         real_data['start_date'].iloc[0] = 0
         real_data['employability_perc'].iloc[2] = 'a'
@@ -56,8 +50,8 @@ class TestColumnShapes:
         column_shape_property = ColumnShapes()
 
         expected_message_1 = re.escape(
-            "Unable to compute Column Shape for column 'start_date'. "
-            "Encountered Error: TypeError '<' not supported between instances of 'str' and 'int'"
+            "Unable to compute Column Shape for column 'start_date'. Encountered Error:"
+            " TypeError '<' not supported between instances of 'Timestamp' and 'int'"
         )
         expected_message_2 = re.escape(
             "Unable to compute Column Shape for column 'employability_perc'. "

--- a/tests/unit/reports/single_table/_properties/test_base.py
+++ b/tests/unit/reports/single_table/_properties/test_base.py
@@ -1,6 +1,8 @@
 """Test BaseSingleTableProperty class."""
+import re
 from unittest.mock import Mock, patch
 
+import pandas as pd
 import pytest
 
 from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
@@ -8,7 +10,7 @@ from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
 
 class TestBaseSingleTableProperty:
 
-    def test__generate_details(self):
+    def test__generate_details_raises_error(self):
         """Test that the method raises a ``NotImplementedError``."""
         # Setup
         base_property = BaseSingleTableProperty()
@@ -25,6 +27,22 @@ class TestBaseSingleTableProperty:
         # Run and Assert
         with pytest.raises(NotImplementedError):
             base_property.get_visualization()
+
+    def test__compute_average_raises_error(self):
+        """Test that the method raises a ``ValueError`` when _details has not been computed."""
+        # Setup
+        base_property = BaseSingleTableProperty()
+
+        # Run and Assert
+        expected_error_message = re.escape(
+            "The property details must be a DataFrame with a 'Score' column."
+        )
+        with pytest.raises(ValueError, match=expected_error_message):
+            base_property._compute_average()
+
+        base_property._details = pd.DataFrame({'Column Name': ['a', 'b', 'c']})
+        with pytest.raises(ValueError, match=expected_error_message):
+            base_property._compute_average()
 
     @patch('sdmetrics.reports.single_table._properties.base.validate_single_table_inputs')
     def test_get_score(self, validate_single_table_inputs_mock):

--- a/tests/unit/reports/single_table/_properties/test_base.py
+++ b/tests/unit/reports/single_table/_properties/test_base.py
@@ -1,24 +1,57 @@
 """Test BaseSingleTableProperty class."""
+from unittest.mock import Mock, patch
+
 import pytest
 
 from sdmetrics.reports.single_table._properties import BaseSingleTableProperty
 
 
-def test_get_score_raises_error():
-    """Test that the method raises a ``NotImplementedError``."""
-    # Setup
-    base_property = BaseSingleTableProperty()
+class TestBaseSingleTableProperty:
 
-    # Run and Assert
-    with pytest.raises(NotImplementedError):
-        base_property.get_score(None, None, None, None)
+    def test__generate_details(self):
+        """Test that the method raises a ``NotImplementedError``."""
+        # Setup
+        base_property = BaseSingleTableProperty()
 
+        # Run and Assert
+        with pytest.raises(NotImplementedError):
+            base_property._generate_details(None, None, None, None)
 
-def test_get_visualization_raises_error():
-    """Test that the method raises a ``NotImplementedError``."""
-    # Setup
-    base_property = BaseSingleTableProperty()
+    def test_get_visualization_raises_error(self):
+        """Test that the method raises a ``NotImplementedError``."""
+        # Setup
+        base_property = BaseSingleTableProperty()
 
-    # Run and Assert
-    with pytest.raises(NotImplementedError):
-        base_property.get_visualization()
+        # Run and Assert
+        with pytest.raises(NotImplementedError):
+            base_property.get_visualization()
+
+    @patch('sdmetrics.reports.single_table._properties.base.validate_single_table_inputs')
+    def test_get_score(self, validate_single_table_inputs_mock):
+        """Test the ``get_score`` method."""
+        # Setup
+        validate_single_table_inputs_mock.return_value = None
+
+        real_data = Mock()
+        synthetic_data = Mock()
+        metadata = Mock()
+        progress_bar = Mock()
+
+        mock_compute_average = Mock()
+        mock__generate_details = Mock(return_value=None)
+
+        base_property = BaseSingleTableProperty()
+        base_property._compute_average = mock_compute_average
+        base_property._generate_details = mock__generate_details
+
+        # Run
+        base_property.get_score(real_data, synthetic_data, metadata, progress_bar)
+
+        # Assert
+        validate_single_table_inputs_mock.assert_called_once_with(
+            real_data, synthetic_data, metadata
+        )
+        mock__generate_details.assert_called_once_with(
+            real_data, synthetic_data, metadata, progress_bar
+        )
+        mock_compute_average.assert_called_once()

--- a/tests/unit/reports/single_table/_properties/test_base.py
+++ b/tests/unit/reports/single_table/_properties/test_base.py
@@ -1,6 +1,6 @@
 """Test BaseSingleTableProperty class."""
 import re
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pandas as pd
 import pytest
@@ -40,15 +40,13 @@ class TestBaseSingleTableProperty:
         with pytest.raises(ValueError, match=expected_error_message):
             base_property._compute_average()
 
-        base_property._details = pd.DataFrame({'Column Name': ['a', 'b', 'c']})
+        base_property._details = pd.DataFrame({'Column': ['a', 'b', 'c']})
         with pytest.raises(ValueError, match=expected_error_message):
             base_property._compute_average()
 
-    @patch('sdmetrics.reports.single_table._properties.base.validate_single_table_inputs')
-    def test_get_score(self, validate_single_table_inputs_mock):
+    def test_get_score(self):
         """Test the ``get_score`` method."""
         # Setup
-        validate_single_table_inputs_mock.return_value = None
 
         real_data = Mock()
         synthetic_data = Mock()
@@ -66,9 +64,6 @@ class TestBaseSingleTableProperty:
         base_property.get_score(real_data, synthetic_data, metadata, progress_bar)
 
         # Assert
-        validate_single_table_inputs_mock.assert_called_once_with(
-            real_data, synthetic_data, metadata
-        )
         mock__generate_details.assert_called_once_with(
             real_data, synthetic_data, metadata, progress_bar
         )

--- a/tests/unit/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/unit/reports/single_table/_properties/test_column_shapes.py
@@ -1,6 +1,6 @@
 
 import re
-from unittest.mock import call, patch
+from unittest.mock import Mock, call, patch
 
 import pandas as pd
 import pytest
@@ -69,5 +69,33 @@ class TestColumnShapes:
         with pytest.warns(UserWarning, match=expected_message):
             column_shape_property._generate_details(real_data, synthetic_data, metadata)
 
-    def test_get_visualization(self):
-        assert True
+    @patch('sdmetrics.reports.single_table._properties.column_shapes.px')
+    def test_get_visualization(self, mock_px):
+        """Test the ``get_visualization`` method."""
+        # Setup
+        column_shape_property = ColumnShapes()
+
+        column_shape_property._details = {
+            'Column': ['Column1', 'Column2'],
+            'Score': [0.7, 0.3],
+            'Metric': ['KSComplement', 'TVComplement']
+        }
+
+        mock__compute_average = Mock(return_value=0.5)
+        column_shape_property._compute_average = mock__compute_average
+
+        mock_bar = Mock()
+        mock_update_yaxes = Mock()
+        mock_update_layout = Mock()
+        mock_px.bar.return_value = mock_bar
+        mock_bar.update_yaxes.return_value = mock_update_yaxes
+        mock_bar.update_layout.return_value = mock_update_layout
+
+        # Run
+        column_shape_property.get_visualization()
+
+        # Assert
+        mock__compute_average.assert_called_once()
+        mock_px.bar.assert_called_once()
+        mock_bar.update_yaxes.assert_called_once()
+        mock_bar.update_layout.assert_called_once()

--- a/tests/unit/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/unit/reports/single_table/_properties/test_column_shapes.py
@@ -1,9 +1,7 @@
-
-import re
 from unittest.mock import Mock, call, patch
 
+import numpy as np
 import pandas as pd
-import pytest
 
 from sdmetrics.reports.single_table._properties.column_shapes import ColumnShapes
 
@@ -53,49 +51,134 @@ class TestColumnShapes:
         ks_complement_compute_mock.assert_has_calls(expected_calls_ksc)
         tv_complement_compute_mock.assert_has_calls(expected_calls_tvc)
 
-    def test__generate_details_warning(self):
-        """Test the ``_generate_details`` method."""
+    @patch('sdmetrics.reports.single_table._properties.column_shapes.KSComplement.compute')
+    @patch('sdmetrics.reports.single_table._properties.column_shapes.TVComplement.compute')
+    def test__generate_details_with_nans(
+        self, tv_complement_compute_mock, ks_complement_compute_mock
+    ):
+        """Test the ``_generate_details`` method when there is NaNs in the data."""
+        # Setup
+        real_data = pd.DataFrame({
+            'col1': [1, None, 3],
+            'col2': [False, True, np.nan],
+            'col3': [None, 'b', 'c'],
+            'col4': pd.to_datetime(['2020-01-01', np.nan, '2020-01-03'])
+        })
+        synthetic_data = pd.DataFrame({
+            'col1': [1, 2, 3],
+            'col2': [False, True, True],
+            'col3': ['a', None, 'c'],
+            'col4': pd.to_datetime(['2020-01-01', '2020-01-02', '2020-01-03'])
+        })
+        metadata = {
+            'columns': {
+                'col1': {'sdtype': 'numerical'},
+                'col2': {'sdtype': 'boolean'},
+                'col3': {'sdtype': 'categorical'},
+                'col4': {'sdtype': 'datetime'}
+            }
+        }
+
+        # Run
+        column_shape_property = ColumnShapes()
+        column_shape_property._generate_details(real_data, synthetic_data, metadata)
+
+        # Assert
+        expected_calls_ksc = [
+            call(real_data['col1'], synthetic_data['col1']),
+            call(real_data['col4'], synthetic_data['col4']),
+        ]
+        expected_calls_tvc = [
+            call(real_data['col2'], synthetic_data['col2']),
+            call(real_data['col3'], synthetic_data['col3']),
+        ]
+
+        ks_complement_compute_mock.assert_has_calls(expected_calls_ksc)
+        tv_complement_compute_mock.assert_has_calls(expected_calls_tvc)
+
+    def test__generate_details_error(self):
+        """Test the ``_generate_details`` method with the error column."""
         # Setup
         real_data = pd.DataFrame({'col1': [1, '2', 3]})
         synthetic_data = pd.DataFrame({'col1': [4, 5, 6]})
         metadata = {'columns': {'col1': {'sdtype': 'numerical'}}}
 
-        # Run and Assert
         column_shape_property = ColumnShapes()
-        expected_message = re.escape(
-            "Unable to compute Column Shape for column 'col1'. Encountered Error: "
-            "TypeError '<' not supported between instances of 'str' and 'int'"
-        )
-        with pytest.warns(UserWarning, match=expected_message):
-            column_shape_property._generate_details(real_data, synthetic_data, metadata)
-
-    @patch('sdmetrics.reports.single_table._properties.column_shapes.px')
-    def test_get_visualization(self, mock_px):
-        """Test the ``get_visualization`` method."""
-        # Setup
-        column_shape_property = ColumnShapes()
-
-        column_shape_property._details = {
-            'Column': ['Column1', 'Column2'],
-            'Score': [0.7, 0.3],
-            'Metric': ['KSComplement', 'TVComplement']
-        }
-
-        mock__compute_average = Mock(return_value=0.5)
-        column_shape_property._compute_average = mock__compute_average
-
-        mock_bar = Mock()
-        mock_update_yaxes = Mock()
-        mock_update_layout = Mock()
-        mock_px.bar.return_value = mock_bar
-        mock_bar.update_yaxes.return_value = mock_update_yaxes
-        mock_bar.update_layout.return_value = mock_update_layout
 
         # Run
-        column_shape_property.get_visualization()
+        result = column_shape_property._generate_details(real_data, synthetic_data, metadata)
 
         # Assert
-        mock__compute_average.assert_called_once()
-        mock_px.bar.assert_called_once()
-        mock_bar.update_yaxes.assert_called_once()
-        mock_bar.update_layout.assert_called_once()
+        expected_message = (
+            "Error: TypeError '<' not supported between instances of 'str' and 'int'"
+        )
+        result_nan = result.loc[pd.isna(result['Score'])]
+        column_names_nan = result_nan['Column'].tolist()
+        error_message = result_nan['Error'].tolist()
+
+        assert column_names_nan == ['col1']
+        assert error_message == [expected_message]
+
+        @patch('sdmetrics.reports.single_table._properties.column_shapes.px')
+        def test_get_visualization(self, mock_px):
+            """Test the ``get_visualization`` method."""
+            # Setup
+            column_shape_property = ColumnShapes()
+
+            mock_df = pd.DataFrame({
+                'Column': ['Column1', 'Column2'],
+                'Score': [0.7, 0.3],
+                'Metric': ['KSComplement', 'TVComplement']
+            })
+            column_shape_property._details = mock_df
+
+            mock__compute_average = Mock(return_value=0.5)
+            column_shape_property._compute_average = mock__compute_average
+
+            mock_bar = Mock()
+            mock_px.bar.return_value = mock_bar
+
+            # Run
+            column_shape_property.get_visualization()
+
+            # Assert
+            mock__compute_average.assert_called_once()
+
+            # Expected call
+            expected_kwargs = {
+                'data_frame': mock_df,
+                'x': 'Column',
+                'y': 'Score',
+                'title': (
+                    'Data Quality: Column Shapes (Average'
+                    f'Score={mock__compute_average.return_value})'
+                ),
+                'category_orders': {'group': mock_df['Column'].tolist()},
+                'color': 'Metric',
+                'color_discrete_map': {
+                    'KSComplement': '#000036',
+                    'TVComplement': '#03AFF1',
+                },
+                'pattern_shape': 'Metric',
+                'pattern_shape_sequence': ['', '/'],
+                'hover_name': 'Column',
+                'hover_data': {
+                    'Column': False,
+                    'Metric': True,
+                    'Score': True,
+                },
+            }
+
+            # Check call_args of mock_px.bar
+            _, kwargs = mock_px.bar.call_args
+
+            # Check DataFrame separately
+            assert kwargs.pop('data_frame').equals(expected_kwargs.pop('data_frame'))
+
+            # Check other arguments
+            assert kwargs == expected_kwargs
+
+            mock_bar.update_yaxes.assert_called_once_with(range=[0, 1])
+            mock_bar.update_layout.assert_called_once_with(
+                xaxis_categoryorder='total ascending', plot_bgcolor='#F5F5F8', margin={'t': 150}
+            )

--- a/tests/unit/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/unit/reports/single_table/_properties/test_column_shapes.py
@@ -1,0 +1,73 @@
+
+import re
+from unittest.mock import call, patch
+
+import pandas as pd
+import pytest
+
+from sdmetrics.reports.single_table._properties.column_shapes import ColumnShapes
+
+
+class TestColumnShapes:
+
+    @patch('sdmetrics.reports.single_table._properties.column_shapes.KSComplement.compute')
+    @patch('sdmetrics.reports.single_table._properties.column_shapes.TVComplement.compute')
+    def test__generate_details(self, tv_complement_compute_mock, ks_complement_compute_mock):
+        """Test the ``_generate_details`` method."""
+        # Setup
+        real_data = pd.DataFrame({
+            'col1': [1, 2, 3],
+            'col2': [False, True, True],
+            'col3': ['a', 'b', 'c'],
+            'col4': pd.to_datetime(['2020-01-01', '2020-01-02', '2020-01-03'])
+        })
+        synthetic_data = pd.DataFrame({
+            'col1': [1, 2, 3],
+            'col2': [False, True, True],
+            'col3': ['a', 'b', 'c'],
+            'col4': pd.to_datetime(['2020-01-01', '2020-01-02', '2020-01-03'])
+        })
+        metadata = {
+            'columns': {
+                'col1': {'sdtype': 'numerical'},
+                'col2': {'sdtype': 'boolean'},
+                'col3': {'sdtype': 'categorical'},
+                'col4': {'sdtype': 'datetime'}
+            }
+        }
+
+        # Run
+        column_shape_property = ColumnShapes()
+        column_shape_property._generate_details(real_data, synthetic_data, metadata)
+
+        # Assert
+        expected_calls_ksc = [
+            call(real_data['col1'], synthetic_data['col1']),
+            call(real_data['col4'], synthetic_data['col4']),
+        ]
+        expected_calls_tvc = [
+            call(real_data['col2'], synthetic_data['col2']),
+            call(real_data['col3'], synthetic_data['col3']),
+        ]
+
+        ks_complement_compute_mock.assert_has_calls(expected_calls_ksc)
+        tv_complement_compute_mock.assert_has_calls(expected_calls_tvc)
+
+    def test__generate_details_warning(self):
+        """Test the ``_generate_details`` method."""
+        # Setup
+        real_data = pd.DataFrame({'col1': [1, '2', 3]})
+        synthetic_data = pd.DataFrame({'col1': [4, 5, 6]})
+        metadata = {'columns': {'col1': {'sdtype': 'numerical'}}}
+
+        # Run and Assert
+        column_shape_property = ColumnShapes()
+        expected_message = re.escape(
+            "Unable to compute Column Shape for column 'col1'. Encountered Error: "
+            "TypeError '<' not supported between instances of 'str' and 'int'"
+        )
+        with pytest.warns(UserWarning, match=expected_message):
+            column_shape_property._generate_details(real_data, synthetic_data, metadata)
+
+    def test_get_visualization(self):
+        assert True

--- a/tests/unit/reports/single_table/_properties/test_column_shapes.py
+++ b/tests/unit/reports/single_table/_properties/test_column_shapes.py
@@ -56,7 +56,7 @@ class TestColumnShapes:
     def test__generate_details_with_nans(
         self, tv_complement_compute_mock, ks_complement_compute_mock
     ):
-        """Test the ``_generate_details`` method when there is NaNs in the data."""
+        """Test the ``_generate_details`` method when there are NaNs in the data."""
         # Setup
         real_data = pd.DataFrame({
             'col1': [1, None, 3],


### PR DESCRIPTION
Resolve #355

I just have some questions:
- What should be the `progress_bar` parameter? Should it have a default value? I put `tqdm.tqdm` as default value (what is done for the reports I think)
- I didn't use the `metric` attribute for the computation, but we maybe need it at another time.

Also, I think `validate_single_table_inputs` that is in `sdmetrics.reports.utils` could be modified to better validate the `data` and `metadata`. We can define a validation method inside `BaseSingleTableProperty` maybe. 
