### PR TITLE
Fix representation of categorical data types in NewRowSynthesis metric

### DIFF
--- a/sdmetrics/single_table/new_row_synthesis.py
+++ b/sdmetrics/single_table/new_row_synthesis.py
@@ -117,10 +117,7 @@ class NewRowSynthesis(SingleTableMetric):
                         f'{abs(numerical_match_tolerance * row[field])}'
                     )
                 elif field in categorical_fields:
-                    if real_data[field].dtype == 'O':
-                        field_filter = f'`{field}` == {repr(row[field])}'
-                    else:
-                        field_filter = f'`{field}` == {row[field]}'
+                    field_filter = f'`{field}` == {repr(row[field])}'
 
                 row_filter.append(field_filter)
 

--- a/tests/unit/single_table/test_new_row_synthesis.py
+++ b/tests/unit/single_table/test_new_row_synthesis.py
@@ -29,7 +29,7 @@ class TestNewRowSynthesis:
             'col4': [1.32, 1.56, 1.21, np.nan, 1.90],
             'col5': [51, 51, 54, 55, 53],
             'col6': ['2020-01-02', '2022-11-24', '2022-06-01', '2021-04-12', '2020-12-11'],
-            'col7': pd.Series(['a', 'b', 'c', 'd', 'b'], dtype='category'),
+            'col7': pd.Series(['a', 'b', 'c', 'b', 'e'], dtype='category'),
         })
         metadata = {
             'primary_key': 'pk',

--- a/tests/unit/single_table/test_new_row_synthesis.py
+++ b/tests/unit/single_table/test_new_row_synthesis.py
@@ -19,6 +19,7 @@ class TestNewRowSynthesis:
             'col4': [1.32, np.nan, 1.43, np.nan, 2.0],
             'col5': [51, 52, 53, 54, 55],
             'col6': ['2020-01-02', '2021-01-04', '2021-05-03', '2022-10-11', '2022-11-13'],
+            'col7': pd.Series(['a', 'b', 'c', 'd', 'b'], dtype='category'),
         })
         synthetic_data = pd.DataFrame({
             'pk': [5, 6, 7, 8, 9],
@@ -28,6 +29,7 @@ class TestNewRowSynthesis:
             'col4': [1.32, 1.56, 1.21, np.nan, 1.90],
             'col5': [51, 51, 54, 55, 53],
             'col6': ['2020-01-02', '2022-11-24', '2022-06-01', '2021-04-12', '2020-12-11'],
+            'col7': pd.Series(['a', 'b', 'c', 'd', 'b'], dtype='category'),
         })
         metadata = {
             'primary_key': 'pk',
@@ -39,6 +41,7 @@ class TestNewRowSynthesis:
                 'col4': {'sdtype': 'numerical'},
                 'col5': {'sdtype': 'categorical'},
                 'col6': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                'col7': {'sdtype': 'categorical'},
             },
         }
         metric = NewRowSynthesis()


### PR DESCRIPTION
Resolves #397.

Reviewing the history of the file, it seems that the condition of checking for the O (object) data type was created to hard-code single quotes around the value instead of using `repr`:

https://github.com/sdv-dev/SDMetrics/blob/585290fc829db32645c1231d5b0385b9e90a0a4c/sdmetrics/single_table/new_row_synthesis.py#L120-L123

But now that we have it, I propose we can remove the else condition as `repr` would handle our edge cases (such as formatting strings with quotes and integers with none).

Let me know if this works. Thank you very much!
