### PR TITLE
Fix `NewRowSynthesis` on datetime columns without formats

### DIFF
--- a/sdmetrics/single_table/new_row_synthesis.py
+++ b/sdmetrics/single_table/new_row_synthesis.py
@@ -73,6 +73,10 @@ class NewRowSynthesis(SingleTableMetric):
 
         for field, field_meta in get_columns_from_metadata(metadata).items():
             if get_type_from_column_meta(field_meta) == 'datetime':
+                if len(real_data[field]) > 0 and isinstance(real_data[field][0], str):
+                    real_data[field] = pd.to_datetime(real_data[field])
+                    synthetic_data[field] = pd.to_datetime(synthetic_data[field])
+
                 real_data[field] = pd.to_numeric(real_data[field])
                 synthetic_data[field] = pd.to_numeric(synthetic_data[field])
 

--- a/tests/integration/single_table/test_single_table.py
+++ b/tests/integration/single_table/test_single_table.py
@@ -147,3 +147,26 @@ def test_newrowsynthesis_with_special_characters_in_column_names():
 
     # Assert
     assert metric == 0.66666666666666667
+
+
+def test_new_row_synthesis_datetime_as_string():
+    """Test it works when the datetime column is a string."""
+    # Setup
+    data = pd.DataFrame(data={
+        'id': [0, 1, 2, 3, 4],
+        'datetime_column': ['2010-02-23', '2010-01-01', '2010-03-30', '2010-03-23', '2010-03-04'],
+        'numerical_column': [1, 2, 3, 4, 5],
+        'categorical_column': [1, 2, 2, 1, 2]
+    })
+
+    # Run
+    metric = NewRowSynthesis.compute(
+        real_data=data,
+        synthetic_data=data,
+        numerical_match_tolerance=0.01,
+        synthetic_sample_size=10_000
+
+    )
+
+    # Assert
+    assert metric == 0.0


### PR DESCRIPTION
CU-860qhu3zr

Partially resolve https://github.com/sdv-dev/SDGym/issues/216 and resolve #337.

This PR adds support for datetime values as strings in `NewRowSynthesis` .