### PR TITLE
Fix title of intertable trends

### DIFF
--- a/sdmetrics/reports/multi_table/_properties/inter_table_trends.py
+++ b/sdmetrics/reports/multi_table/_properties/inter_table_trends.py
@@ -193,7 +193,7 @@ class InterTableTrends(BaseMultiTableProperty):
             to_plot,
             x='Columns',
             y='Score',
-            title=f'Data Quality: Column Shapes (Average Score={average_score})',
+            title=f'Data Quality: Intertable Trends (Average Score={average_score})',
             category_orders={'group': to_plot['Columns']},
             color='Metric',
             color_discrete_map={

--- a/tests/unit/reports/multi_table/_properties/test_inter_table_trends.py
+++ b/tests/unit/reports/multi_table/_properties/test_inter_table_trends.py
@@ -204,7 +204,7 @@ def test_get_visualization(plotly_mock):
         DataFrameMatcher(expected_plot_df),
         x='Columns',
         y='Score',
-        title='Data Quality: Column Shapes (Average Score=1.0)',
+        title='Data Quality: Intertable Trends (Average Score=1.0)',
         category_orders={'group': SeriesMatcher(expected_plot_df['Columns'])},
         color='Metric',
         color_discrete_map={
@@ -270,7 +270,7 @@ def test_get_visualization_multiple_relationships(plotly_mock):
         DataFrameMatcher(expected_plot_df),
         x='Columns',
         y='Score',
-        title='Data Quality: Column Shapes (Average Score=0.75)',
+        title='Data Quality: Intertable Trends (Average Score=0.75)',
         category_orders={'group': SeriesMatcher(expected_plot_df['Columns'])},
         color='Metric',
         color_discrete_map={


### PR DESCRIPTION
Clickup:
CU-86ayjev9x

resolves #477 

Change the title name of graph to "Intertable Trends" instead of "Column Shapes"