### PR TITLE
Make quality reports fault tolerant on missing relationships in metadata

### DIFF
--- a/sdmetrics/reports/multi_table/_properties/base.py
+++ b/sdmetrics/reports/multi_table/_properties/base.py
@@ -59,12 +59,11 @@ class BaseMultiTableProperty():
         """Average the scores for each column."""
         is_dataframe = isinstance(self.details, pd.DataFrame)
         has_score_column = 'Score' in self.details.columns
-        assert_message = "The property details must be a DataFrame with a 'Score' column."
+        assert_message = "The property details must be in a DataFrame with a 'Score' column."
 
+        assert is_dataframe, assert_message
         if not has_score_column:
             return np.nan
-        assert is_dataframe, assert_message
-        assert has_score_column, assert_message
 
         return self.details['Score'].mean()
 

--- a/sdmetrics/reports/multi_table/_properties/base.py
+++ b/sdmetrics/reports/multi_table/_properties/base.py
@@ -46,13 +46,12 @@ class BaseMultiTableProperty():
             return sum([(n_cols * (n_cols - 1)) // 2 for n_cols in num_columns])
         elif self._num_iteration_case == 'inter_table_column_pair':
             iterations = 0
-            if 'relationships' in metadata:
-                for relationship in metadata['relationships']:
-                    parent_columns = \
-                        metadata['tables'][relationship['parent_table_name']]['columns']
-                    child_columns = \
-                        metadata['tables'][relationship['child_table_name']]['columns']
-                    iterations += (len(parent_columns) * len(child_columns))
+            for relationship in metadata.get('relationships', []):
+                parent_columns = \
+                    metadata['tables'][relationship['parent_table_name']]['columns']
+                child_columns = \
+                    metadata['tables'][relationship['child_table_name']]['columns']
+                iterations += (len(parent_columns) * len(child_columns))
             return iterations
 
     def _compute_average(self):

--- a/sdmetrics/reports/multi_table/_properties/inter_table_trends.py
+++ b/sdmetrics/reports/multi_table/_properties/inter_table_trends.py
@@ -106,40 +106,40 @@ class InterTableTrends(BaseMultiTableProperty):
                 The progress bar object. Defaults to None.
         """
         all_details = []
-        if 'relationships' in metadata:
-            for relationship in metadata['relationships']:
-                parent = relationship['parent_table_name']
-                child = relationship['child_table_name']
-                foreign_key = relationship['child_foreign_key']
+        for relationship in metadata.get('relationships', []):
+            parent = relationship['parent_table_name']
+            child = relationship['child_table_name']
+            foreign_key = relationship['child_foreign_key']
 
-                denormalized_real, denormalized_synthetic = self._denormalize_tables(
-                    real_data,
-                    synthetic_data,
-                    relationship
-                )
+            denormalized_real, denormalized_synthetic = self._denormalize_tables(
+                real_data,
+                synthetic_data,
+                relationship
+            )
 
-                merged_metadata, parent_cols, child_cols = self._merge_metadata(
-                    metadata,
-                    parent,
-                    child
-                )
+            merged_metadata, parent_cols, child_cols = self._merge_metadata(
+                metadata,
+                parent,
+                child
+            )
 
-                parent_child_pairs = itertools.product(parent_cols, child_cols)
+            parent_child_pairs = itertools.product(parent_cols, child_cols)
 
-                self._properties[(parent, child, foreign_key)] = SingleTableColumnPairTrends()
-                details = self._properties[(parent, child, foreign_key)]._generate_details(
-                    denormalized_real, denormalized_synthetic, merged_metadata,
-                    progress_bar=progress_bar, column_pairs=parent_child_pairs
-                )
+            self._properties[(parent, child, foreign_key)] = SingleTableColumnPairTrends()
+            details = self._properties[(parent, child, foreign_key)]._generate_details(
+                denormalized_real, denormalized_synthetic, merged_metadata,
+                progress_bar=progress_bar, column_pairs=parent_child_pairs
+            )
 
-                details['Parent Table'] = parent
-                details['Child Table'] = child
-                details['Foreign Key'] = foreign_key
-                if not details.empty:
-                    details['Column 1'] = details['Column 1'].str.replace(f'{parent}.', '', n=1)
-                    details['Column 2'] = details['Column 2'].str.replace(f'{child}.', '', n=1)
-                all_details.append(details)
+            details['Parent Table'] = parent
+            details['Child Table'] = child
+            details['Foreign Key'] = foreign_key
+            if not details.empty:
+                details['Column 1'] = details['Column 1'].str.replace(f'{parent}.', '', n=1)
+                details['Column 2'] = details['Column 2'].str.replace(f'{child}.', '', n=1)
+            all_details.append(details)
 
+        if len(all_details) > 0:
             self.details = pd.concat(all_details, axis=0).reset_index(drop=True)
             detail_columns = [
                 'Parent Table', 'Child Table', 'Foreign Key', 'Column 1', 'Column 2',

--- a/sdmetrics/reports/multi_table/_properties/inter_table_trends.py
+++ b/sdmetrics/reports/multi_table/_properties/inter_table_trends.py
@@ -106,48 +106,49 @@ class InterTableTrends(BaseMultiTableProperty):
                 The progress bar object. Defaults to None.
         """
         all_details = []
-        for relationship in metadata['relationships']:
-            parent = relationship['parent_table_name']
-            child = relationship['child_table_name']
-            foreign_key = relationship['child_foreign_key']
+        if 'relationships' in metadata:
+            for relationship in metadata['relationships']:
+                parent = relationship['parent_table_name']
+                child = relationship['child_table_name']
+                foreign_key = relationship['child_foreign_key']
 
-            denormalized_real, denormalized_synthetic = self._denormalize_tables(
-                real_data,
-                synthetic_data,
-                relationship
-            )
+                denormalized_real, denormalized_synthetic = self._denormalize_tables(
+                    real_data,
+                    synthetic_data,
+                    relationship
+                )
 
-            merged_metadata, parent_cols, child_cols = self._merge_metadata(
-                metadata,
-                parent,
-                child
-            )
+                merged_metadata, parent_cols, child_cols = self._merge_metadata(
+                    metadata,
+                    parent,
+                    child
+                )
 
-            parent_child_pairs = itertools.product(parent_cols, child_cols)
+                parent_child_pairs = itertools.product(parent_cols, child_cols)
 
-            self._properties[(parent, child, foreign_key)] = SingleTableColumnPairTrends()
-            details = self._properties[(parent, child, foreign_key)]._generate_details(
-                denormalized_real, denormalized_synthetic, merged_metadata,
-                progress_bar=progress_bar, column_pairs=parent_child_pairs
-            )
+                self._properties[(parent, child, foreign_key)] = SingleTableColumnPairTrends()
+                details = self._properties[(parent, child, foreign_key)]._generate_details(
+                    denormalized_real, denormalized_synthetic, merged_metadata,
+                    progress_bar=progress_bar, column_pairs=parent_child_pairs
+                )
 
-            details['Parent Table'] = parent
-            details['Child Table'] = child
-            details['Foreign Key'] = foreign_key
-            if not details.empty:
-                details['Column 1'] = details['Column 1'].str.replace(f'{parent}.', '', n=1)
-                details['Column 2'] = details['Column 2'].str.replace(f'{child}.', '', n=1)
-            all_details.append(details)
+                details['Parent Table'] = parent
+                details['Child Table'] = child
+                details['Foreign Key'] = foreign_key
+                if not details.empty:
+                    details['Column 1'] = details['Column 1'].str.replace(f'{parent}.', '', n=1)
+                    details['Column 2'] = details['Column 2'].str.replace(f'{child}.', '', n=1)
+                all_details.append(details)
 
-        self.details = pd.concat(all_details, axis=0).reset_index(drop=True)
-        detail_columns = [
-            'Parent Table', 'Child Table', 'Foreign Key', 'Column 1', 'Column 2',
-            'Metric', 'Score', 'Real Correlation', 'Synthetic Correlation'
-        ]
-        if 'Error' in self.details.columns:
-            detail_columns.append('Error')
+            self.details = pd.concat(all_details, axis=0).reset_index(drop=True)
+            detail_columns = [
+                'Parent Table', 'Child Table', 'Foreign Key', 'Column 1', 'Column 2',
+                'Metric', 'Score', 'Real Correlation', 'Synthetic Correlation'
+            ]
+            if 'Error' in self.details.columns:
+                detail_columns.append('Error')
 
-        self.details = self.details[detail_columns]
+            self.details = self.details[detail_columns]
 
     def get_visualization(self, table_name=None):
         """Create a plot to show the inter table trends data.

--- a/tests/integration/reports/multi_table/test_quality_report.py
+++ b/tests/integration/reports/multi_table/test_quality_report.py
@@ -306,3 +306,24 @@ def test_quality_report_with_errors():
     assert score == 0.7008862433862433
     pd.testing.assert_frame_equal(properties, expected_properties)
     pd.testing.assert_frame_equal(details_column_shapes, expected_details)
+
+
+def test_quality_report_with_no_relationships():
+    # Setup
+    real_data, synthetic_data, metadata = load_demo(modality='multi_table')
+
+    del metadata['relationships']
+    report = QualityReport()
+
+    # Run
+    report.generate(real_data, synthetic_data, metadata, verbose=True)
+    score = report.get_score()
+
+    # Assert
+    expected_properties = pd.DataFrame({
+        'Property': ['Column Shapes', 'Column Pair Trends', 'Cardinality', 'Intertable Trends'],
+        'Score': [0.792262, 0.424967, np.nan, np.nan]
+    })
+    properties = report.get_properties()
+    pd.testing.assert_frame_equal(properties, expected_properties)
+    assert score == 0.6086142240422239

--- a/tests/unit/reports/multi_table/_properties/test_base.py
+++ b/tests/unit/reports/multi_table/_properties/test_base.py
@@ -1,6 +1,5 @@
 """Test BaseMultiTableProperty class."""
 
-import re
 from unittest.mock import Mock
 
 import numpy as np
@@ -176,21 +175,15 @@ class TestBaseMultiTableProperty():
         with pytest.raises(NotImplementedError):
             base_property._generate_details(None, None, None, None)
 
-    def test__compute_average_raises_error(self):
+    def test__compute_average_sends_nan(self):
         """Test that the method raises an error when _details has not been computed."""
         # Setup
         base_property = BaseMultiTableProperty()
 
         # Run and Assert
-        expected_error_message = re.escape(
-            "The property details must be a DataFrame with a 'Score' column."
-        )
-        with pytest.raises(AssertionError, match=expected_error_message):
-            base_property._compute_average()
-
+        assert np.isnan(base_property._compute_average())
         base_property.details = pd.DataFrame({'Column': ['a', 'b', 'c']})
-        with pytest.raises(AssertionError, match=expected_error_message):
-            base_property._compute_average()
+        assert np.isnan(base_property._compute_average())
 
     def test_get_score(self):
         """Test the ``get_score`` method."""


### PR DESCRIPTION
CU-86ayjkavn
#86ayjkavn

resolves #481 

Missing relationship metadata no longer throws an error but instead returns NaN for the score report for multitable data.
