### PR TITLE
Fix: Sometimes graphs not being generated in jupyter notebook

### DIFF
--- a/sdmetrics/reports/base_report.py
+++ b/sdmetrics/reports/base_report.py
@@ -13,6 +13,7 @@ import pkg_resources
 import tqdm
 
 from sdmetrics.reports.utils import convert_datetime_columns
+from sdmetrics.visualization import set_plotly_config
 
 
 class BaseReport():
@@ -199,6 +200,7 @@ class BaseReport():
             'Score': score,
         })
 
+    @set_plotly_config
     def get_visualization(self, property_name):
         """Return a visualization for each score for the given property name.
 

--- a/sdmetrics/reports/multi_table/base_multi_table_report.py
+++ b/sdmetrics/reports/multi_table/base_multi_table_report.py
@@ -1,5 +1,6 @@
 """Single table base property class."""
 from sdmetrics.reports.base_report import BaseReport
+from sdmetrics.visualization import set_plotly_config
 
 
 class BaseMultiTableReport(BaseReport):
@@ -84,6 +85,7 @@ class BaseMultiTableReport(BaseReport):
         details = self._properties[property_name].get_details(table_name)
         return details.copy()
 
+    @set_plotly_config
     def get_visualization(self, property_name, table_name=None):
         """Return a visualization for the given property and table_name.
 

--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -23,13 +23,17 @@ def set_plotly_config(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
         renderers = list(pio.renderers)
-        builtin = globals().get('__builtin__', {})
-        get_ipython = getattr(builtin, 'get_ipython') if hasattr(builtin, 'get_ipython') else False
-        if get_ipython:
+        try:
+            # Lazy import IPython
+            from IPython import get_ipython
+
             ipython_interpreter = str(get_ipython())
             if 'ZMQInteractiveShell' in ipython_interpreter and 'iframe' in renderers:
-                # This means we are in jupyter notebook
+                # This means we are using jupyter notebook
                 pio.renderers.default = 'iframe'
+
+        except Exception:
+            pass
 
         return function(*args, **kwargs)
 

--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -27,13 +27,9 @@ def set_plotly_config(function):
         get_ipython = getattr(builtin, 'get_ipython') if hasattr(builtin, 'get_ipython') else False
         if get_ipython:
             ipython_interpreter = str(get_ipython())
-            if 'colab' in ipython_interpreter and 'colab' in renderers:
-                pio.renderers.default = 'colab'
-            elif 'ZMQInteractiveShell' in ipython_interpreter and 'iframe' in renderers:
+            if 'ZMQInteractiveShell' in ipython_interpreter and 'iframe' in renderers:
+                # This means we are in jupyter notebook
                 pio.renderers.default = 'iframe'
-
-        elif 'iframe' in renderers:
-            pio.renderers.default = 'iframe'
 
         return function(*args, **kwargs)
 

--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -3,10 +3,28 @@
 import pandas as pd
 import plotly.express as px
 import plotly.figure_factory as ff
+import plotly.io as pio
 from pandas.api.types import is_datetime64_dtype
 
 from sdmetrics.reports.utils import PlotConfig
 from sdmetrics.utils import get_missing_percentage, is_datetime
+
+
+def _set_plotly_config():
+    """Set the ``plotly`` config according to the environment."""
+    renderers = list(pio.renderers)
+    if getattr('get_ipython', __builtin__):
+        ipython_interpreter = get_ipython()
+        if 'colab' in ipython_interpreter and 'colab' in renderers:
+            pio.renderers.default = 'colab'
+        elif 'ZMQInteractiveShell' in ipython_interpreter and 'notebook' in renderers:
+            pio.renderers.default = 'notebook'
+
+    elif 'iframe' in renderers:
+        pio.renderers.default = 'iframe'
+
+
+_set_plotly_config()
 
 
 def _generate_column_bar_plot(real_data, synthetic_data, plot_kwargs={}):

--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -26,7 +26,7 @@ def set_plotly_config(function):
         builtin = globals().get('__builtin__', {})
         get_ipython = getattr(builtin, 'get_ipython') if hasattr(builtin, 'get_ipython') else False
         if get_ipython:
-            ipython_interpreter = get_ipython()
+            ipython_interpreter = str(get_ipython())
             if 'colab' in ipython_interpreter and 'colab' in renderers:
                 pio.renderers.default = 'colab'
             elif 'ZMQInteractiveShell' in ipython_interpreter and 'iframe' in renderers:

--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -16,9 +16,9 @@ def set_plotly_config(function):
     """Set the ``plotly.io.renders`` config according to the environment.
 
     Configure the rendering settings based on the environment in which the plot is generated
-    to ensure the image rendering with a stable engine. When working in Google Colab,
-    the default ``colab`` rendering option provided by ``plotly`` will be used.
-    For other environments, like ``Jupyter Notebooks``, select the `iframe` rendering engine.
+    to ensure the image rendering with a stable engine. For other environments, like
+    ``Jupyter Notebooks``, select the ``iframe`` rendering engine otherwise leave the default
+    one.
     """
     @wraps(function)
     def wrapper(*args, **kwargs):

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -700,3 +700,31 @@ def test_get_column_pair_plot_plot_type_is_box(mock__generate_heatmap_plot):
         ['amount', 'date']
     )
     assert fig == mock__generate_heatmap_plot.return_value
+
+
+@patch('sdmetrics.visualization.pio')
+def test_get_column_pair_plot_sets_plotly_renderers(mock_pio):
+    """Ensure that the ``plotly.io`` render is set to ``iframe``."""
+    # Setup
+    def mock_iter():
+        yield from ['iframe', 'notebook', 'colab']
+
+    mock_pio.renderers = Mock()
+    mock_pio.renderers.__iter__ = Mock(side_effect=mock_iter)
+    mock_pio.renderers.default = 'default'
+
+    columns = ['amount', 'date']
+    real_data = pd.DataFrame({
+        'amount': [1, 2, 3],
+        'date': pd.to_datetime(['2021-01-01', '2022-01-01', '2023-01-01'])
+    })
+    synthetic_data = pd.DataFrame({
+        'amount': [1., 2., 3.],
+        'date': pd.to_datetime(['2021-01-01', '2022-01-01', '2023-01-01'])
+    })
+
+    # Run
+    get_column_pair_plot(real_data, synthetic_data, columns, plot_type='heatmap')
+
+    # Assert
+    assert mock_pio.renderers.default == 'iframe'

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -700,31 +700,3 @@ def test_get_column_pair_plot_plot_type_is_box(mock__generate_heatmap_plot):
         ['amount', 'date']
     )
     assert fig == mock__generate_heatmap_plot.return_value
-
-
-@patch('sdmetrics.visualization.pio')
-def test_get_column_pair_plot_sets_plotly_renderers(mock_pio):
-    """Ensure that the ``plotly.io`` render is set to ``iframe``."""
-    # Setup
-    def mock_iter():
-        yield from ['iframe', 'notebook', 'colab']
-
-    mock_pio.renderers = Mock()
-    mock_pio.renderers.__iter__ = Mock(side_effect=mock_iter)
-    mock_pio.renderers.default = 'default'
-
-    columns = ['amount', 'date']
-    real_data = pd.DataFrame({
-        'amount': [1, 2, 3],
-        'date': pd.to_datetime(['2021-01-01', '2022-01-01', '2023-01-01'])
-    })
-    synthetic_data = pd.DataFrame({
-        'amount': [1., 2., 3.],
-        'date': pd.to_datetime(['2021-01-01', '2022-01-01', '2023-01-01'])
-    })
-
-    # Run
-    get_column_pair_plot(real_data, synthetic_data, columns, plot_type='heatmap')
-
-    # Assert
-    assert mock_pio.renderers.default == 'iframe'


### PR DESCRIPTION
CU-860q76vnz
Resolves #322 

Add a function to set the `plotly` default render depending on the environment.

[Here is a notebook in google colab](https://colab.research.google.com/drive/1gKyCQX-ztpVozRxU76rHtNT1B7YFA0Tw?usp=sharing) that maintains the functionality there. Please try in a local environment to ensure that the `iframe` engine is being used.
