### PR TITLE
`UserWarning: KeyError: 'relationships'` in DiagnosticReport if metadata missing relationships

### DIFF
--- a/sdmetrics/reports/multi_table/_properties/base.py
+++ b/sdmetrics/reports/multi_table/_properties/base.py
@@ -1,6 +1,4 @@
 """Multi table base property class."""
-import warnings
-
 import numpy as np
 import pandas as pd
 
@@ -37,9 +35,7 @@ class BaseMultiTableProperty():
         elif self._num_iteration_case == 'relationship':
             try:
                 return len(metadata['relationships'])
-            except KeyError as e:
-                message = f'{type(e).__name__}: {e}. No relationships found in the data.'
-                warnings.warn(message)
+            except KeyError:
                 return 0
         elif self._num_iteration_case == 'column_pair':
             num_columns = [len(table['columns']) for table in metadata['tables'].values()]

--- a/tests/integration/reports/multi_table/test_diagnostic_report.py
+++ b/tests/integration/reports/multi_table/test_diagnostic_report.py
@@ -172,13 +172,12 @@ class TestDiagnosticReport:
 
         pd.testing.assert_frame_equal(details, expected_dataframe)
 
+    @pytest.mark.filterwarnings('error::UserWarning')
     def test_metadata_without_relationship(self):
-        """Test that no warning is raised when the metadata does not contain relationships."""
         # Setup
         real_data, synthetic_data, metadata = load_demo(modality='multi_table')
         del metadata['relationships']
         report = DiagnosticReport()
 
         # Run and Assert
-        with pytest.warns(None):
-            report.generate(real_data, synthetic_data, metadata)
+        report.generate(real_data, synthetic_data, metadata)

--- a/tests/integration/reports/multi_table/test_diagnostic_report.py
+++ b/tests/integration/reports/multi_table/test_diagnostic_report.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from sdmetrics.demos import load_demo
 from sdmetrics.reports.multi_table import DiagnosticReport
@@ -170,3 +171,14 @@ class TestDiagnosticReport:
         })
 
         pd.testing.assert_frame_equal(details, expected_dataframe)
+
+    def test_metadata_without_relationship(self):
+        """Test that no warning is raised when the metadata does not contain relationships."""
+        # Setup
+        real_data, synthetic_data, metadata = load_demo(modality='multi_table')
+        del metadata['relationships']
+        report = DiagnosticReport()
+
+        # Run and Assert
+        with pytest.warns(None):
+            report.generate(real_data, synthetic_data, metadata)


### PR DESCRIPTION
CU-86ayp29ez
Resolve #506