### PR TITLE
Better error message when passing an SDV Metadata object

### DIFF
--- a/sdmetrics/reports/base_report.py
+++ b/sdmetrics/reports/base_report.py
@@ -143,7 +143,10 @@ class BaseReport:
                 Whether or not to print report summary and progress.
         """
         if not isinstance(metadata, dict):
-            raise TypeError('The provided metadata is not a dictionary.')
+            raise TypeError(
+                f"Expected a dictionary but received a '{type(metadata).__name__}' instead."
+                " For SDV metadata objects, please use the 'to_dict' function to convert it to a dictionary."
+            )
 
         self._validate(real_data, synthetic_data, metadata)
         self.convert_datetimes(real_data, synthetic_data, metadata)

--- a/sdmetrics/reports/multi_table/base_multi_table_report.py
+++ b/sdmetrics/reports/multi_table/base_multi_table_report.py
@@ -101,8 +101,10 @@ class BaseMultiTableReport(BaseReport):
             verbose (bool):
                 Whether or not to print report summary and progress.
         """
+        results = super().generate(real_data, synthetic_data, metadata, verbose)
         self.table_names = list(metadata.get('tables', {}).keys())
-        return super().generate(real_data, synthetic_data, metadata, verbose)
+
+        return results
 
     def _check_table_names(self, table_name):
         if table_name not in self.table_names:

--- a/tests/unit/reports/test_base_report.py
+++ b/tests/unit/reports/test_base_report.py
@@ -232,7 +232,10 @@ class TestBaseReport:
         metadata = 'metadata'
 
         # Run and Assert
-        expected_message = 'The provided metadata is not a dictionary.'
+        expected_message = (
+            "Expected a dictionary but received a 'str' instead. For SDV metadata objects, "
+            "please use the 'to_dict' function to convert it to a dictionary."
+        )
         with pytest.raises(TypeError, match=expected_message):
             base_report.generate(real_data, synthetic_data, metadata, verbose=False)
 


### PR DESCRIPTION
CU-86b1d39h0
Resolve #610

Tested on SDV:
<img width="1281" alt="Screenshot 2024-07-29 at 12 29 42" src="https://github.com/user-attachments/assets/d635caa7-c8ba-404c-b85d-6b63bf09078f">
