### PR TITLE
Try to improve performance of contingency_similarity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ exclude = [
     ".git",
     "__pycache__",
     ".ipynb_checkpoints",
+    ".ipynb",
     "tasks.py",
 ]
 

--- a/sdmetrics/column_pairs/statistical/contingency_similarity.py
+++ b/sdmetrics/column_pairs/statistical/contingency_similarity.py
@@ -26,30 +26,91 @@ class ContingencySimilarity(ColumnPairsMetric):
     max_value = 1.0
 
     @classmethod
-    def new_compute(cls, real_data, synthetic_data):
-        columns = real_data.columns[:2]
-        real = real_data[columns]
-        synthetic = synthetic_data[columns]
-        contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
-        contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
-        combined_index = contingency_real.index.union(contingency_synthetic.index)
-        contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
-        contingency_real = contingency_real.reindex(combined_index, fill_value=0)
-        diff = abs(contingency_real - contingency_synthetic).fillna(0)
-        variation = diff / 2
-        return 1 - variation.sum()
-        # contingency_real = contingency_real.unstack(level=1, fill_value=0)
-        # contingency_synthetic = contingency_synthetic.unstack(level=1, fill_value=0)
-        # all_columns = contingency_real.columns.union(contingency_synthetic.columns)
-        # all_indices = contingency_real.index.union(contingency_synthetic.index)
-        # contingency_real = contingency_real.reindex(
-        #     index=all_indices, columns=all_columns, fill_value=0
-        # )
-        # contingency_synthetic = contingency_synthetic.reindex(
-        #     index=all_indices, columns=all_columns, fill_value=0
-        # )
-        # variation = abs(contingency_real - contingency_synthetic) / 2
-        # return 1 - variation.sum().sum()
+    def _compute_by_method(cls, real_data, synthetic_data, method='old'):
+        if method == 'old':
+            columns = real_data.columns[:2]
+            real = real_data[columns]
+            synthetic = synthetic_data[columns]
+            contingency_real = pd.crosstab(
+                index=real[columns[0]].astype(str),
+                columns=real[columns[1]].astype(str),
+                normalize=True,
+            )
+            contingency_synthetic = pd.crosstab(
+                index=synthetic[columns[0]].astype(str),
+                columns=synthetic[columns[1]].astype(str),
+                normalize=True,
+            )
+
+            real_append_cols = {}
+            for col in set(contingency_synthetic.columns) - set(contingency_real.columns):
+                real_append_cols[col] = [0 for _ in range(len(contingency_real))]
+            contingency_real = pd.concat(
+                (contingency_real, pd.DataFrame(real_append_cols, index=contingency_real.index)),
+                axis=1,
+            )
+
+            synthetic_append_cols = {}
+            for col in set(contingency_real.columns) - set(contingency_synthetic.columns):
+                synthetic_append_cols[col] = [0 for _ in range(len(contingency_synthetic))]
+            contingency_synthetic = pd.concat(
+                (
+                    contingency_synthetic,
+                    pd.DataFrame(synthetic_append_cols, index=contingency_synthetic.index),
+                ),
+                axis=1,
+            )
+
+            for row in set(contingency_synthetic.index) - set(contingency_real.index):
+                contingency_real.loc[row] = [0 for _ in range(len(contingency_real.columns))]
+            for row in set(contingency_real.index) - set(contingency_synthetic.index):
+                contingency_synthetic.loc[row] = [0 for _ in range(len(contingency_synthetic.columns))]
+
+            variation = abs(contingency_real - contingency_synthetic) / 2
+            return 1 - variation.sum().sum()
+        elif method == 'groupby_reindex_unstack':
+            columns = real_data.columns[:2]
+            real = real_data[columns]
+            synthetic = synthetic_data[columns]
+            contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
+            contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
+            combined_index = contingency_real.index.union(contingency_synthetic.index)
+            contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
+            contingency_real = contingency_real.reindex(combined_index, fill_value=0)
+            contingency_real = contingency_real.unstack(level=1, fill_value=0)  # noqa: PD010
+            contingency_synthetic = contingency_synthetic.unstack(level=1, fill_value=0)  # noqa: PD010
+            variation = abs(contingency_real - contingency_synthetic) / 2
+            return 1 - variation.sum().sum()
+        elif method == 'groupby_unstack_reindex':
+            columns = real_data.columns[:2]
+            real = real_data[columns]
+            synthetic = synthetic_data[columns]
+            contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
+            contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
+            contingency_real = contingency_real.unstack(level=1, fill_value=0)  # noqa: PD010
+            contingency_synthetic = contingency_synthetic.unstack(level=1, fill_value=0)  # noqa: PD010
+            all_columns = contingency_real.columns.union(contingency_synthetic.columns)
+            all_indices = contingency_real.index.union(contingency_synthetic.index)
+            contingency_real = contingency_real.reindex(
+                index=all_indices, columns=all_columns, fill_value=0
+            )
+            contingency_synthetic = contingency_synthetic.reindex(
+                index=all_indices, columns=all_columns, fill_value=0
+            )
+            variation = abs(contingency_real - contingency_synthetic) / 2
+            return 1 - variation.sum().sum()
+        elif method == 'groupby_reindex':
+            columns = real_data.columns[:2]
+            real = real_data[columns]
+            synthetic = synthetic_data[columns]
+            contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
+            contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
+            combined_index = contingency_real.index.union(contingency_synthetic.index)
+            contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
+            contingency_real = contingency_real.reindex(combined_index, fill_value=0)
+            diff = abs(contingency_real - contingency_synthetic).fillna(0)
+            variation = diff / 2
+            return 1 - variation.sum()
 
     @classmethod
     def compute(cls, real_data, synthetic_data):
@@ -65,47 +126,7 @@ class ContingencySimilarity(ColumnPairsMetric):
             float:
                 The contingency similarity of the two columns.
         """
-        columns = real_data.columns[:2]
-        real = real_data[columns]
-        synthetic = synthetic_data[columns]
-        # contingency_real = pd.crosstab(
-        #     index=real[columns[0]].astype(str),
-        #     columns=real[columns[1]].astype(str),
-        #     normalize=True,
-        # )
-        # contingency_synthetic = pd.crosstab(
-        #     index=synthetic[columns[0]].astype(str),
-        #     columns=synthetic[columns[1]].astype(str),
-        #     normalize=True,
-        # )
-
-        # real_append_cols = {}
-        # for col in set(contingency_synthetic.columns) - set(contingency_real.columns):
-        #     real_append_cols[col] = [0 for _ in range(len(contingency_real))]
-        # contingency_real = pd.concat(
-        #     (contingency_real, pd.DataFrame(real_append_cols, index=contingency_real.index)),
-        #     axis=1,
-        # )
-
-        # synthetic_append_cols = {}
-        # for col in set(contingency_real.columns) - set(contingency_synthetic.columns):
-        #     synthetic_append_cols[col] = [0 for _ in range(len(contingency_synthetic))]
-        # contingency_synthetic = pd.concat(
-        #     (
-        #         contingency_synthetic,
-        #         pd.DataFrame(synthetic_append_cols, index=contingency_synthetic.index),
-        #     ),
-        #     axis=1,
-        # )
-
-        # for row in set(contingency_synthetic.index) - set(contingency_real.index):
-        #     contingency_real.loc[row] = [0 for _ in range(len(contingency_real.columns))]
-        # for row in set(contingency_real.index) - set(contingency_synthetic.index):
-        #     contingency_synthetic.loc[row] = [0 for _ in range(len(contingency_synthetic.columns))]
-
-        # variation = abs(contingency_real - contingency_synthetic) / 2
-        # return 1 - variation.sum().sum()
-        return cls.new_compute(real_data, synthetic_data)
+        return cls._compute_by_method(real_data, synthetic_data)
 
     @classmethod
     def normalize(cls, raw_score):

--- a/sdmetrics/column_pairs/statistical/contingency_similarity.py
+++ b/sdmetrics/column_pairs/statistical/contingency_similarity.py
@@ -1,6 +1,5 @@
 """Contingency Similarity Metric."""
 
-import pandas as pd
 
 from sdmetrics.column_pairs.base import ColumnPairsMetric
 from sdmetrics.goal import Goal

--- a/sdmetrics/column_pairs/statistical/contingency_similarity.py
+++ b/sdmetrics/column_pairs/statistical/contingency_similarity.py
@@ -26,6 +26,32 @@ class ContingencySimilarity(ColumnPairsMetric):
     max_value = 1.0
 
     @classmethod
+    def new_compute(cls, real_data, synthetic_data):
+        columns = real_data.columns[:2]
+        real = real_data[columns]
+        synthetic = synthetic_data[columns]
+        contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
+        contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
+        combined_index = contingency_real.index.union(contingency_synthetic.index)
+        contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
+        contingency_real = contingency_real.reindex(combined_index, fill_value=0)
+        diff = abs(contingency_real - contingency_synthetic).fillna(0)
+        variation = diff / 2
+        return 1 - variation.sum()
+        # contingency_real = contingency_real.unstack(level=1, fill_value=0)
+        # contingency_synthetic = contingency_synthetic.unstack(level=1, fill_value=0)
+        # all_columns = contingency_real.columns.union(contingency_synthetic.columns)
+        # all_indices = contingency_real.index.union(contingency_synthetic.index)
+        # contingency_real = contingency_real.reindex(
+        #     index=all_indices, columns=all_columns, fill_value=0
+        # )
+        # contingency_synthetic = contingency_synthetic.reindex(
+        #     index=all_indices, columns=all_columns, fill_value=0
+        # )
+        # variation = abs(contingency_real - contingency_synthetic) / 2
+        # return 1 - variation.sum().sum()
+
+    @classmethod
     def compute(cls, real_data, synthetic_data):
         """Compare the contingency similarity of two discrete columns.
 
@@ -42,43 +68,44 @@ class ContingencySimilarity(ColumnPairsMetric):
         columns = real_data.columns[:2]
         real = real_data[columns]
         synthetic = synthetic_data[columns]
-        contingency_real = pd.crosstab(
-            index=real[columns[0]].astype(str),
-            columns=real[columns[1]].astype(str),
-            normalize=True,
-        )
-        contingency_synthetic = pd.crosstab(
-            index=synthetic[columns[0]].astype(str),
-            columns=synthetic[columns[1]].astype(str),
-            normalize=True,
-        )
+        # contingency_real = pd.crosstab(
+        #     index=real[columns[0]].astype(str),
+        #     columns=real[columns[1]].astype(str),
+        #     normalize=True,
+        # )
+        # contingency_synthetic = pd.crosstab(
+        #     index=synthetic[columns[0]].astype(str),
+        #     columns=synthetic[columns[1]].astype(str),
+        #     normalize=True,
+        # )
 
-        real_append_cols = {}
-        for col in set(contingency_synthetic.columns) - set(contingency_real.columns):
-            real_append_cols[col] = [0 for _ in range(len(contingency_real))]
-        contingency_real = pd.concat(
-            (contingency_real, pd.DataFrame(real_append_cols, index=contingency_real.index)),
-            axis=1,
-        )
+        # real_append_cols = {}
+        # for col in set(contingency_synthetic.columns) - set(contingency_real.columns):
+        #     real_append_cols[col] = [0 for _ in range(len(contingency_real))]
+        # contingency_real = pd.concat(
+        #     (contingency_real, pd.DataFrame(real_append_cols, index=contingency_real.index)),
+        #     axis=1,
+        # )
 
-        synthetic_append_cols = {}
-        for col in set(contingency_real.columns) - set(contingency_synthetic.columns):
-            synthetic_append_cols[col] = [0 for _ in range(len(contingency_synthetic))]
-        contingency_synthetic = pd.concat(
-            (
-                contingency_synthetic,
-                pd.DataFrame(synthetic_append_cols, index=contingency_synthetic.index),
-            ),
-            axis=1,
-        )
+        # synthetic_append_cols = {}
+        # for col in set(contingency_real.columns) - set(contingency_synthetic.columns):
+        #     synthetic_append_cols[col] = [0 for _ in range(len(contingency_synthetic))]
+        # contingency_synthetic = pd.concat(
+        #     (
+        #         contingency_synthetic,
+        #         pd.DataFrame(synthetic_append_cols, index=contingency_synthetic.index),
+        #     ),
+        #     axis=1,
+        # )
 
-        for row in set(contingency_synthetic.index) - set(contingency_real.index):
-            contingency_real.loc[row] = [0 for _ in range(len(contingency_real.columns))]
-        for row in set(contingency_real.index) - set(contingency_synthetic.index):
-            contingency_synthetic.loc[row] = [0 for _ in range(len(contingency_synthetic.columns))]
+        # for row in set(contingency_synthetic.index) - set(contingency_real.index):
+        #     contingency_real.loc[row] = [0 for _ in range(len(contingency_real.columns))]
+        # for row in set(contingency_real.index) - set(contingency_synthetic.index):
+        #     contingency_synthetic.loc[row] = [0 for _ in range(len(contingency_synthetic.columns))]
 
-        variation = abs(contingency_real - contingency_synthetic) / 2
-        return 1 - variation.sum().sum()
+        # variation = abs(contingency_real - contingency_synthetic) / 2
+        # return 1 - variation.sum().sum()
+        return cls.new_compute(real_data, synthetic_data)
 
     @classmethod
     def normalize(cls, raw_score):

--- a/sdmetrics/column_pairs/statistical/contingency_similarity.py
+++ b/sdmetrics/column_pairs/statistical/contingency_similarity.py
@@ -42,7 +42,9 @@ class ContingencySimilarity(ColumnPairsMetric):
         real = real_data[columns]
         synthetic = synthetic_data[columns]
         contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
-        contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
+        contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(
+            synthetic
+        )
         combined_index = contingency_real.index.union(contingency_synthetic.index)
         contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
         contingency_real = contingency_real.reindex(combined_index, fill_value=0)

--- a/sdmetrics/column_pairs/statistical/contingency_similarity.py
+++ b/sdmetrics/column_pairs/statistical/contingency_similarity.py
@@ -26,93 +26,6 @@ class ContingencySimilarity(ColumnPairsMetric):
     max_value = 1.0
 
     @classmethod
-    def _compute_by_method(cls, real_data, synthetic_data, method='old'):
-        if method == 'old':
-            columns = real_data.columns[:2]
-            real = real_data[columns]
-            synthetic = synthetic_data[columns]
-            contingency_real = pd.crosstab(
-                index=real[columns[0]].astype(str),
-                columns=real[columns[1]].astype(str),
-                normalize=True,
-            )
-            contingency_synthetic = pd.crosstab(
-                index=synthetic[columns[0]].astype(str),
-                columns=synthetic[columns[1]].astype(str),
-                normalize=True,
-            )
-
-            real_append_cols = {}
-            for col in set(contingency_synthetic.columns) - set(contingency_real.columns):
-                real_append_cols[col] = [0 for _ in range(len(contingency_real))]
-            contingency_real = pd.concat(
-                (contingency_real, pd.DataFrame(real_append_cols, index=contingency_real.index)),
-                axis=1,
-            )
-
-            synthetic_append_cols = {}
-            for col in set(contingency_real.columns) - set(contingency_synthetic.columns):
-                synthetic_append_cols[col] = [0 for _ in range(len(contingency_synthetic))]
-            contingency_synthetic = pd.concat(
-                (
-                    contingency_synthetic,
-                    pd.DataFrame(synthetic_append_cols, index=contingency_synthetic.index),
-                ),
-                axis=1,
-            )
-
-            for row in set(contingency_synthetic.index) - set(contingency_real.index):
-                contingency_real.loc[row] = [0 for _ in range(len(contingency_real.columns))]
-            for row in set(contingency_real.index) - set(contingency_synthetic.index):
-                contingency_synthetic.loc[row] = [0 for _ in range(len(contingency_synthetic.columns))]
-
-            variation = abs(contingency_real - contingency_synthetic) / 2
-            return 1 - variation.sum().sum()
-        elif method == 'groupby_reindex_unstack':
-            columns = real_data.columns[:2]
-            real = real_data[columns]
-            synthetic = synthetic_data[columns]
-            contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
-            contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
-            combined_index = contingency_real.index.union(contingency_synthetic.index)
-            contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
-            contingency_real = contingency_real.reindex(combined_index, fill_value=0)
-            contingency_real = contingency_real.unstack(level=1, fill_value=0)  # noqa: PD010
-            contingency_synthetic = contingency_synthetic.unstack(level=1, fill_value=0)  # noqa: PD010
-            variation = abs(contingency_real - contingency_synthetic) / 2
-            return 1 - variation.sum().sum()
-        elif method == 'groupby_unstack_reindex':
-            columns = real_data.columns[:2]
-            real = real_data[columns]
-            synthetic = synthetic_data[columns]
-            contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
-            contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
-            contingency_real = contingency_real.unstack(level=1, fill_value=0)  # noqa: PD010
-            contingency_synthetic = contingency_synthetic.unstack(level=1, fill_value=0)  # noqa: PD010
-            all_columns = contingency_real.columns.union(contingency_synthetic.columns)
-            all_indices = contingency_real.index.union(contingency_synthetic.index)
-            contingency_real = contingency_real.reindex(
-                index=all_indices, columns=all_columns, fill_value=0
-            )
-            contingency_synthetic = contingency_synthetic.reindex(
-                index=all_indices, columns=all_columns, fill_value=0
-            )
-            variation = abs(contingency_real - contingency_synthetic) / 2
-            return 1 - variation.sum().sum()
-        elif method == 'groupby_reindex':
-            columns = real_data.columns[:2]
-            real = real_data[columns]
-            synthetic = synthetic_data[columns]
-            contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
-            contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
-            combined_index = contingency_real.index.union(contingency_synthetic.index)
-            contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
-            contingency_real = contingency_real.reindex(combined_index, fill_value=0)
-            diff = abs(contingency_real - contingency_synthetic).fillna(0)
-            variation = diff / 2
-            return 1 - variation.sum()
-
-    @classmethod
     def compute(cls, real_data, synthetic_data):
         """Compare the contingency similarity of two discrete columns.
 
@@ -126,7 +39,17 @@ class ContingencySimilarity(ColumnPairsMetric):
             float:
                 The contingency similarity of the two columns.
         """
-        return cls._compute_by_method(real_data, synthetic_data)
+        columns = real_data.columns[:2]
+        real = real_data[columns]
+        synthetic = synthetic_data[columns]
+        contingency_real = real.groupby(list(columns), dropna=False).size() / len(real)
+        contingency_synthetic = synthetic.groupby(list(columns), dropna=False).size() / len(synthetic)
+        combined_index = contingency_real.index.union(contingency_synthetic.index)
+        contingency_synthetic = contingency_synthetic.reindex(combined_index, fill_value=0)
+        contingency_real = contingency_real.reindex(combined_index, fill_value=0)
+        diff = abs(contingency_real - contingency_synthetic).fillna(0)
+        variation = diff / 2
+        return 1 - variation.sum()
 
     @classmethod
     def normalize(cls, raw_score):

--- a/sdmetrics/column_pairs/statistical/contingency_similarity.py
+++ b/sdmetrics/column_pairs/statistical/contingency_similarity.py
@@ -1,6 +1,5 @@
 """Contingency Similarity Metric."""
 
-
 from sdmetrics.column_pairs.base import ColumnPairsMetric
 from sdmetrics.goal import Goal
 

--- a/tests/integration/reports/multi_table/_properties/test_inter_table_trends.py
+++ b/tests/integration/reports/multi_table/_properties/test_inter_table_trends.py
@@ -17,7 +17,7 @@ class TestInterTableTrends:
         result = inter_table_trends.get_score(real_data, synthetic_data, metadata)
 
         # Assert
-        assert result == 0.4416666666666667
+        assert result == 0.4416666666666666
 
     def test_with_progress_bar(self):
         """Test that the progress bar is correctly updated."""
@@ -38,5 +38,5 @@ class TestInterTableTrends:
         result = inter_table_trends.get_score(real_data, synthetic_data, metadata, progress_bar)
 
         # Assert
-        assert result == 0.4416666666666667
+        assert result == 0.4416666666666666
         assert mock_update.call_count == num_iter

--- a/tests/integration/reports/multi_table/test_quality_report.py
+++ b/tests/integration/reports/multi_table/test_quality_report.py
@@ -232,9 +232,9 @@ def test_quality_report_end_to_end():
     # Assert
     expected_properties = pd.DataFrame({
         'Property': ['Column Shapes', 'Column Pair Trends', 'Cardinality', 'Intertable Trends'],
-        'Score': [0.7978174603174604, 0.45654629583521095, 0.95, 0.4416666666666667],
+        'Score': [0.7978174603174604, 0.45654629583521095, 0.95, 0.4416666666666666],
     })
-    assert score == 0.6615076057048345
+    assert score == 0.6615076057048344
     pd.testing.assert_frame_equal(properties, expected_properties)
     expected_info_keys = {
         'report_type',
@@ -272,9 +272,9 @@ def test_quality_report_with_object_datetimes():
     # Assert
     expected_properties = pd.DataFrame({
         'Property': ['Column Shapes', 'Column Pair Trends', 'Cardinality', 'Intertable Trends'],
-        'Score': [0.7978174603174604, 0.45654629583521095, 0.95, 0.4416666666666667],
+        'Score': [0.7978174603174604, 0.45654629583521095, 0.95, 0.4416666666666666],
     })
-    assert score == 0.6615076057048345
+    assert score == 0.6615076057048344
     pd.testing.assert_frame_equal(properties, expected_properties)
 
 
@@ -342,7 +342,7 @@ def test_quality_report_with_errors():
             None,
         ],
     })
-    assert score == 0.7249603174603175
+    assert score == 0.7249603174603174
     pd.testing.assert_frame_equal(properties, expected_properties)
     pd.testing.assert_frame_equal(details_column_shapes, expected_details)
 


### PR DESCRIPTION
resolves #622 

Below is the profiling of the `QualityReport` before the changes. As you can see most time was spent in the `crosstab` method. 
<img width="1358" alt="old_code_100_000" src="https://github.com/user-attachments/assets/bcf03050-7fc9-4d24-b4d4-da08d84274a5">


To improve this, I switched to using `groupby` instead. `Groupby` seems to be faster than `crosstab` and `pivot_table` according to this [post](https://ramiro.org/notebook/pandas-crosstab-groupby-pivot/) and trials I ran. The one issue is that `groupby` returns data as a multi-indexed series instead of a table with the different column values on one axis and the different row values on the other. To compute the metric, I could either use `unstack` to convert the return value of `groupby` to the table we wanted, or change the logic to sum over the multi-indexed series. I tried both examples and show their results below. I used the same dataset for each method.

### Results for all methods at 1000 rows
<img width="604" alt="Screenshot 2024-08-20 at 11 46 11 AM" src="https://github.com/user-attachments/assets/44ab8626-0479-4422-838c-04b1e0931ac4">

### Results for all methods at 10,000 rows
<img width="598" alt="Screenshot 2024-08-20 at 11 48 15 AM" src="https://github.com/user-attachments/assets/1ff941ec-af80-48cf-9d47-4b7f191c2280">

### Results for all methods at 1,000,000 rows
![image](https://github.com/user-attachments/assets/1c6c5df4-64a8-457c-a235-6be79f20ec6f)

As you can see, as the number of rows increases, the gap in time between methods decreases. Despite that, groupby was always faster. The specific method of groupby that was fastest seemed to vary based on number of rows.

Below is the profiling for each method.
### Using groupby, unstack and reindexing after unstacking
<img width="1308" alt="groupby_unstack_reindex" src="https://github.com/user-attachments/assets/efb5aa69-9a93-42f3-b7c1-82a34a15604c">


### Using groupby, unsstack and reindexing before unstacking
<img width="1349" alt="groupby_reindex_unstack" src="https://github.com/user-attachments/assets/c2ed3cf3-a719-4ea3-b0ff-106da1cc071b">


### Using groupby on its own
<img width="1339" alt="Screenshot 2024-08-20 at 11 57 15 AM" src="https://github.com/user-attachments/assets/faad2468-5c68-4824-8b7b-fd0495a1f649">
