### PR TITLE
`DisclosureProtection` should be NaN if baseline score is zero and fix warning message

### DIFF
--- a/sdmetrics/single_table/privacy/disclosure_protection.py
+++ b/sdmetrics/single_table/privacy/disclosure_protection.py
@@ -14,7 +14,7 @@ from sdmetrics.single_table.privacy.cap import (
     CategoricalZeroCAP,
 )
 
-MAX_NUM_ROWS = 50000
+MAX_NUM_ROWS = 10000
 
 CAP_METHODS = {
     'CAP': CategoricalCAP,
@@ -212,7 +212,7 @@ class DisclosureProtection(SingleTableMetric):
         computation_method = computation_method.upper()
         if len(real_data) > MAX_NUM_ROWS or len(synthetic_data) > MAX_NUM_ROWS:
             warnings.warn(
-                f'Data exceeds {MAX_NUM_ROWS} rows, perfomance may be slow.'
+                f'Data exceeds {MAX_NUM_ROWS} rows, perfomance may be slow. '
                 'Consider using the `DisclosureProtectionEstimate` for faster computation.'
             )
 
@@ -238,7 +238,7 @@ class DisclosureProtection(SingleTableMetric):
         )
 
         if baseline_protection == 0:
-            score = 0 if cap_protection == 0 else 1
+            score = np.nan
         else:
             score = min(cap_protection / baseline_protection, 1)
 
@@ -363,7 +363,7 @@ class DisclosureProtectionEstimate(DisclosureProtection):
             estimated_score_sum += estimated_cap_protection
             average_computed_score = estimated_score_sum / (i + 1.0)
             if baseline_protection == 0:
-                average_score = 0 if average_computed_score == 0 else 1
+                average_score = np.nan
             else:
                 average_score = min(average_computed_score / baseline_protection, 1)
 

--- a/tests/unit/single_table/privacy/test_disclosure_protection.py
+++ b/tests/unit/single_table/privacy/test_disclosure_protection.py
@@ -271,15 +271,7 @@ class TestDisclosureProtection:
         CAPMethodsMock.get.return_value = CAPMock
 
         # Run
-        score_breakdown_with_cap = DisclosureProtection.compute_breakdown(
-            real_data=real_data,
-            synthetic_data=synthetic_data,
-            known_column_names=['col1'],
-            sensitive_column_names=['col2'],
-        )
-
-        CAPMock._compute.return_value = 0
-        score_breakdown_no_cap = DisclosureProtection.compute_breakdown(
+        score_breakdown = DisclosureProtection.compute_breakdown(
             real_data=real_data,
             synthetic_data=synthetic_data,
             known_column_names=['col1'],
@@ -287,12 +279,11 @@ class TestDisclosureProtection:
         )
 
         # Assert
-        assert score_breakdown_with_cap == {
-            'score': 1,
+        assert score_breakdown == {
+            'score': np.nan,
             'baseline_protection': 0,
             'cap_protection': 0.5,
         }
-        assert score_breakdown_no_cap == {'score': 0, 'baseline_protection': 0, 'cap_protection': 0}
 
     @patch('sdmetrics.single_table.privacy.disclosure_protection.CAP_METHODS')
     @patch(
@@ -323,7 +314,7 @@ class TestDisclosureProtection:
 
         # Run
         expected_warning = re.escape(
-            'Data exceeds 50000 rows, perfomance may be slow.'
+            'Data exceeds 10000 rows, perfomance may be slow. '
             'Consider using the `DisclosureProtectionEstimate` for faster computation.'
         )
         with pytest.warns(UserWarning, match=expected_warning):
@@ -486,7 +477,7 @@ class TestDisclosureProtectionEstimate:
         )
 
         # Assert
-        assert avg_score == 1
+        assert np.isnan(avg_score)
         assert avg_computed_score == 0.38
 
     @patch(


### PR DESCRIPTION
Resolve #693, resolve #694
CU-86b34yyzp