### PR TITLE
Cancel previous workflow runs on a new push 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   minimum:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ${{ matrix.os }}

--- a/scripts/release_notes_generator.py
+++ b/scripts/release_notes_generator.py
@@ -23,6 +23,14 @@ ISSUE_LABELS = [
     'feature request',
     'customer success',
 ]
+ISSUE_LABELS_ORDERED_BY_IMPORTANCE = [
+    'feature request',
+    'customer success',
+    'bug',
+    'documentation',
+    'internal',
+    'maintenance',
+]
 NEW_LINE = '\n'
 GITHUB_URL = 'https://api.github.com/repos/sdv-dev/sdmetrics'
 GITHUB_TOKEN = os.getenv('GH_ACCESS_TOKEN')
@@ -36,10 +44,12 @@ def _get_milestone_number(milestone_title):
     body = response.json()
     if response.status_code != 200:
         raise Exception(str(body))
+
     milestones = body
     for milestone in milestones:
         if milestone.get('title') == milestone_title:
             return milestone.get('number')
+
     raise ValueError(f'Milestone {milestone_title} not found in past 100 milestones.')
 
 
@@ -57,16 +67,22 @@ def _get_issues_by_milestone(milestone):
         body = response.json()
         if response.status_code != 200:
             raise Exception(str(body))
+
         issues_on_page = body
         if not issues_on_page:
             break
+
+        # Filter our PRs
+        issues_on_page = [issue for issue in issues_on_page if issue.get('pull_request') is None]
         issues.extend(issues_on_page)
         page += 1
+
     return issues
 
 
 def _get_issues_by_category(release_issues):
     category_to_issues = defaultdict(list)
+
     for issue in release_issues:
         issue_title = issue['title']
         issue_number = issue['number']
@@ -76,6 +92,7 @@ def _get_issues_by_category(release_issues):
         if assignee:
             login = assignee['login']
             line += f' by @{login}'
+
         # Check if any known label is marked on the issue
         labels = [label['name'] for label in issue['labels']]
         found_category = False
@@ -84,22 +101,27 @@ def _get_issues_by_category(release_issues):
                 category_to_issues[category].append(line)
                 found_category = True
                 break
+
         if not found_category:
             category_to_issues['misc'].append(line)
+
     return category_to_issues
 
 
 def _create_release_notes(issues_by_category, version, date):
     title = f'## v{version} - {date}'
     release_notes = f'{title}{NEW_LINE}{NEW_LINE}'
-    for category in ISSUE_LABELS + ['misc']:
+
+    for category in ISSUE_LABELS_ORDERED_BY_IMPORTANCE + ['misc']:
         issues = issues_by_category.get(category)
         if issues:
             section_text = (
                 f'### {LABEL_TO_HEADER[category]}{NEW_LINE}{NEW_LINE}'
                 f'{NEW_LINE.join(issues)}{NEW_LINE}{NEW_LINE}'
             )
+
             release_notes += section_text
+
     return release_notes
 
 
@@ -108,10 +130,12 @@ def update_release_notes(release_notes):
     file_path = 'HISTORY.md'
     with open(file_path, 'r') as history_file:
         history = history_file.read()
+
     token = '# HISTORY\n\n'
     split_index = history.find(token) + len(token) + 1
     header = history[:split_index]
     new_notes = f'{header}{release_notes}{history[split_index:]}'
+
     with open(file_path, 'w') as new_history_file:
         new_history_file.write(new_notes)
 


### PR DESCRIPTION
CU-86b3ffpek
Resolve #705 
When pushing a new commit to a PR, cancel old jobs in progress