### PR TITLE
Cap the version of XGBoost to < 3.0.0 so tests can pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ torch = [
     "torch>=2.6.0;python_version>='3.13'",
 ]
 pomegranate = ['pomegranate>=1.1.2,<2.0']
-xgboost = ['xgboost>=2.1.3']
+xgboost = ['xgboost>=2.1.3,<3.0.0']
 test = [
     'sdmetrics[pomegranate,torch,xgboost]',
     'pytest>=6.2.5,<7',


### PR DESCRIPTION
Failing tests on main: https://github.com/sdv-dev/SDMetrics/actions/runs/13907397105/job/38913529506?pr=747

Looks like XGBoost got a major update to [3.0.0](https://github.com/dmlc/xgboost/releases/tag/v3.0.0)
BinaryClassifier Tests are failing due to different values being calculated for our tests.