### PR TITLE
Optimize DCR calculation using vector operations

### DIFF
--- a/sdmetrics/single_table/privacy/dcr_baseline_protection.py
+++ b/sdmetrics/single_table/privacy/dcr_baseline_protection.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sdmetrics._utils_metadata import _process_data_with_metadata
 from sdmetrics.goal import Goal
 from sdmetrics.single_table.base import SingleTableMetric
-from sdmetrics.single_table.privacy.dcr_utils import calculate_dcr, calculate_dcr_optimized
+from sdmetrics.single_table.privacy.dcr_utils import calculate_dcr_optimized
 from sdmetrics.single_table.privacy.util import validate_num_samples_num_iteration
 from sdmetrics.utils import is_datetime
 
@@ -119,12 +119,6 @@ class DCRBaselineProtection(SingleTableMetric):
             dcr_random = calculate_dcr_optimized(
                 reference_dataset=sanitized_real_data, dataset=random_sample, metadata=metadata
             )
-            print('DCR Random')
-            print(type(dcr_random))
-            print(dcr_random)
-            print(dcr_random.median())
-            print(f'DCR REAL')
-            print(dcr_real.median())
             synthetic_data_median = dcr_real.median()
             random_data_median = dcr_random.median()
             score = np.nan

--- a/sdmetrics/single_table/privacy/dcr_baseline_protection.py
+++ b/sdmetrics/single_table/privacy/dcr_baseline_protection.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sdmetrics._utils_metadata import _process_data_with_metadata
 from sdmetrics.goal import Goal
 from sdmetrics.single_table.base import SingleTableMetric
-from sdmetrics.single_table.privacy.dcr_utils import calculate_dcr
+from sdmetrics.single_table.privacy.dcr_utils import calculate_dcr, calculate_dcr_optimized
 from sdmetrics.single_table.privacy.util import validate_num_samples_num_iteration
 from sdmetrics.utils import is_datetime
 
@@ -113,12 +113,18 @@ class DCRBaselineProtection(SingleTableMetric):
                 synthetic_sample = sanitized_synthetic_data.sample(n=num_rows_subsample)
                 random_sample = random_data.sample(n=num_rows_subsample)
 
-            dcr_real = calculate_dcr(
-                real_data=sanitized_real_data, synthetic_data=synthetic_sample, metadata=metadata
+            dcr_real = calculate_dcr_optimized(
+                reference_dataset=sanitized_real_data, dataset=synthetic_sample, metadata=metadata
             )
-            dcr_random = calculate_dcr(
-                real_data=sanitized_real_data, synthetic_data=random_sample, metadata=metadata
+            dcr_random = calculate_dcr_optimized(
+                reference_dataset=sanitized_real_data, dataset=random_sample, metadata=metadata
             )
+            print('DCR Random')
+            print(type(dcr_random))
+            print(dcr_random)
+            print(dcr_random.median())
+            print(f'DCR REAL')
+            print(dcr_real.median())
             synthetic_data_median = dcr_real.median()
             random_data_median = dcr_random.median()
             score = np.nan

--- a/sdmetrics/single_table/privacy/dcr_baseline_protection.py
+++ b/sdmetrics/single_table/privacy/dcr_baseline_protection.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sdmetrics._utils_metadata import _process_data_with_metadata
 from sdmetrics.goal import Goal
 from sdmetrics.single_table.base import SingleTableMetric
-from sdmetrics.single_table.privacy.dcr_utils import calculate_dcr_optimized
+from sdmetrics.single_table.privacy.dcr_utils import calculate_dcr
 from sdmetrics.single_table.privacy.util import validate_num_samples_num_iteration
 from sdmetrics.utils import is_datetime
 
@@ -113,10 +113,10 @@ class DCRBaselineProtection(SingleTableMetric):
                 synthetic_sample = sanitized_synthetic_data.sample(n=num_rows_subsample)
                 random_sample = random_data.sample(n=num_rows_subsample)
 
-            dcr_real = calculate_dcr_optimized(
+            dcr_real = calculate_dcr(
                 reference_dataset=sanitized_real_data, dataset=synthetic_sample, metadata=metadata
             )
-            dcr_random = calculate_dcr_optimized(
+            dcr_random = calculate_dcr(
                 reference_dataset=sanitized_real_data, dataset=random_sample, metadata=metadata
             )
             synthetic_data_median = dcr_real.median()

--- a/sdmetrics/single_table/privacy/dcr_overfitting_protection.py
+++ b/sdmetrics/single_table/privacy/dcr_overfitting_protection.py
@@ -128,10 +128,10 @@ class DCROverfittingProtection(SingleTableMetric):
                 synthetic_sample = sanitized_synthetic_data.sample(n=num_rows_subsample)
 
             dcr_real = calculate_dcr(
-                real_data=training_data, synthetic_data=synthetic_sample, metadata=metadata
+                reference_dataset=training_data, dataset=synthetic_sample, metadata=metadata
             )
             dcr_holdout = calculate_dcr(
-                real_data=validation_data, synthetic_data=synthetic_sample, metadata=metadata
+                reference_dataset=validation_data, dataset=synthetic_sample, metadata=metadata
             )
 
             num_rows_closer_to_real = np.where(dcr_real < dcr_holdout, 1.0, 0.0).sum()

--- a/sdmetrics/single_table/privacy/dcr_utils.py
+++ b/sdmetrics/single_table/privacy/dcr_utils.py
@@ -7,157 +7,7 @@ from sdmetrics._utils_metadata import _process_data_with_metadata
 from sdmetrics.utils import get_columns_from_metadata
 
 
-def _calculate_dcr_value(synthetic_value, real_value, sdtype, col_range=None):
-    """Calculate the Distance to Closest Record between two different values.
-
-    Arguments:
-        synthetic_value (int, float, datetime, boolean, string, or None):
-            The synthetic value that we are calculating DCR value for
-        real_value (int, float, datetime, boolean, string, or None):
-            The data value that we are referencing for measuring DCR.
-        sdtype (string):
-            The sdtype of the column values.
-        col_range (float):
-            The range of values for a column used for numerical values to calculate DCR.
-            Defaults to None.
-
-    Returns:
-       float:
-            Returns dcr value between two given values.
-    """
-    if pd.isna(synthetic_value) and pd.isna(real_value):
-        return 0.0
-    elif pd.isna(synthetic_value) or pd.isna(real_value):
-        return 1.0
-
-    if sdtype == 'numerical' or sdtype == 'datetime':
-        if col_range is None:
-            raise ValueError(
-                'No col_range was provided. The col_range is required '
-                'for numerical and datetime sdtype DCR calculation.'
-            )
-
-        difference = abs(synthetic_value - real_value)
-        if isinstance(difference, pd.Timedelta):
-            difference = difference.total_seconds()
-
-        distance = 0.0 if synthetic_value == real_value else 1.0
-        if col_range != 0:
-            distance = difference / col_range
-
-        return min(distance, 1.0)
-
-    if synthetic_value == real_value:
-        return 0.0
-    else:
-        return 1.0
-
-
-def _calculate_dcr_between_rows(synthetic_row, comparison_row, column_ranges, metadata):
-    """Calculate the Distance to Closest Record between two rows.
-
-    Arguments:
-        synthetic_row (pandas.Series):
-            The synthetic row that we are calculating DCR value for.
-        comparison_row (pandas.Series):
-            The data value that we are referencing for measuring DCR.
-        column_ranges (dict):
-            A dictionary that defines the range for each numerical column.
-        metadata (dict):
-            The metadata dict.
-
-    Returns:
-        float:
-            Returns DCR value (the average value of DCR values we computed across the row).
-    """
-    dcr_values = synthetic_row.index.to_series().apply(
-        lambda synthetic_column_name: _calculate_dcr_value(
-            synthetic_row[synthetic_column_name],
-            comparison_row[synthetic_column_name],
-            metadata['columns'][synthetic_column_name]['sdtype'],
-            column_ranges.get(synthetic_column_name),
-        )
-    )
-
-    return dcr_values.mean()
-
-
-def _calculate_dcr_between_row_and_data(synthetic_row, real_data, column_ranges, metadata):
-    """Calculate the DCR between a single row in the synthetic data and another dataset.
-
-    Arguments:
-        synthetic_row (pandas.Series):
-            The synthetic row that we are calculating DCR against an entire dataset.
-        real_data (pandas.Dataframe):
-            The dataset that acts as the reference for DCR calculations.
-        column_ranges (dict):
-            A dictionary that defines the range for each numerical column.
-        metadata (dict):
-            The metadata dict.
-
-    Returns:
-        float:
-            Returns the minimum distance to closest record computed between the
-            synthetic row and the reference dataset.
-    """
-    synthetic_distance_to_all_real = real_data.apply(
-        lambda real_row: _calculate_dcr_between_rows(
-            synthetic_row, real_row, column_ranges, metadata
-        ),
-        axis=1,
-    )
-    return synthetic_distance_to_all_real.min()
-
-
-def calculate_dcr(real_data, synthetic_data, metadata):
-    """Calculate the Distance to Closest Record for all rows in the synthetic data.
-
-    Arguments:
-        real_data (pandas.Dataframe):
-            The dataset that acts as the reference for DCR calculations. Ranges are determined from
-            this dataset.
-        synthetic_data (pandas.Dataframe):
-            The synthetic data that we are calculating DCR values for. Every row will be measured
-            against the comparison data.
-        metadata (dict):
-            The metadata dict.
-
-    Returns:
-        pandas.Series:
-            Returns a Series that shows the DCR value for every row of synthetic data.
-    """
-    column_ranges = {}
-
-    real_data_copy = real_data.copy()
-    synthetic_data_copy = synthetic_data.copy()
-    real_data_copy = _process_data_with_metadata(real_data_copy, metadata, True)
-    synthetic_data_copy = _process_data_with_metadata(synthetic_data_copy, metadata, True)
-
-    overlapping_columns = set(real_data_copy.columns) & set(synthetic_data_copy.columns)
-    if not overlapping_columns:
-        raise ValueError('There are no overlapping statistical columns to measure.')
-
-    for col_name, column in get_columns_from_metadata(metadata).items():
-        sdtype = column['sdtype']
-        col_range = None
-        if sdtype == 'numerical' or sdtype == 'datetime':
-            col_range = real_data_copy[col_name].max() - real_data_copy[col_name].min()
-            if isinstance(col_range, pd.Timedelta):
-                col_range = col_range.total_seconds()
-
-        column_ranges[col_name] = col_range
-
-    dcr_dist_df = synthetic_data_copy.apply(
-        lambda synth_row: _calculate_dcr_between_row_and_data(
-            synth_row, real_data_copy, column_ranges, metadata
-        ),
-        axis=1,
-    )
-
-    return dcr_dist_df
-
-
-def calculate_dcr_optimized(dataset, reference_dataset, metadata):
+def calculate_dcr(dataset, reference_dataset, metadata):
     """Calculate the Distance to Closest Record for all rows in the synthetic data.
 
     Arguments:
@@ -175,16 +25,17 @@ def calculate_dcr_optimized(dataset, reference_dataset, metadata):
     dataset_copy = _process_data_with_metadata(dataset.copy(), metadata, True)
     reference_copy = _process_data_with_metadata(reference_dataset.copy(), metadata, True)
 
-    # figure out which columns we want to keep for the computation
-    # for this proof-of-concept, I've only implemented it on numerical and categorical
-    # for the numerical columns, calculate the range based on the reference data
+    common_cols = set(dataset_copy.columns) & set(reference_copy.columns)
     cols_to_keep = []
     ranges = {}
 
     for col_name, col_metadata in get_columns_from_metadata(metadata).items():
         sdtype = col_metadata['sdtype']
 
-        if sdtype in ['numerical', 'categorical', 'boolean', 'datetime']:
+        if (
+            sdtype in ['numerical', 'categorical', 'boolean', 'datetime']
+            and col_name in common_cols
+        ):
             cols_to_keep.append(col_name)
 
             if sdtype in ['numerical', 'datetime']:
@@ -203,43 +54,61 @@ def calculate_dcr_optimized(dataset, reference_dataset, metadata):
     reference_copy = reference_copy[cols_to_keep]
     reference_copy['index'] = [i for i in range(len(reference_copy))]
 
-    full_dataset = dataset_copy.merge(reference_copy, how='cross', suffixes=('_data', '_ref'))
+    results = []
+    chunk_size = 1000
 
-    # on the full dataset, we can now perform column-wise operations to compute differences
-    # these are vectorized so they will be much faster
-    for col_name in cols_to_keep:
-        sdtype = metadata['columns'][col_name]['sdtype']
-        if sdtype == 'numerical' or sdtype == 'datetime':
-            diff = (full_dataset[col_name + '_ref'] - full_dataset[col_name + '_data']).abs()
-            if isinstance(diff.iloc[0], pd.Timedelta):
-                diff = diff.dt.total_seconds()
+    for chunk_start in range(0, len(dataset_copy), chunk_size):
+        chunk = dataset_copy.iloc[chunk_start : chunk_start + chunk_size].copy()
+        chunk['index'] = range(chunk_start, chunk_start + len(chunk))
 
-            full_dataset[col_name + '_diff'] = np.where(
-                ranges[col_name] == 0,
-                np.where(
-                    (
-                        full_dataset[col_name + '_ref'].isna()
-                        & ~full_dataset[col_name + '_data'].isna()
-                    )
-                    | (
-                        ~full_dataset[col_name + '_ref'].isna()
-                        & full_dataset[col_name + '_data'].isna()
-                    ),
-                    1,
+        reference_copy['index'] = range(len(reference_copy))
+        full_dataset = chunk.merge(reference_copy, how='cross', suffixes=('_data', '_ref'))
+
+        for col_name in cols_to_keep:
+            sdtype = metadata['columns'][col_name]['sdtype']
+            if sdtype in ['numerical', 'datetime']:
+                diff = (full_dataset[col_name + '_ref'] - full_dataset[col_name + '_data']).abs()
+                if pd.api.types.is_timedelta64_dtype(diff):
+                    diff = diff.dt.total_seconds()
+
+                full_dataset[col_name + '_diff'] = np.where(
+                    ranges[col_name] == 0,
                     (diff > 0).astype(int),
-                ),
-                np.minimum(diff / ranges[col_name], 1.0),
-            )
+                    np.minimum(diff / ranges[col_name], 1.0),
+                )
 
-        elif sdtype == 'categorical' or sdtype == 'boolean':
-            equals_cat = (full_dataset[col_name + '_ref'] == full_dataset[col_name + '_data']) | (
-                full_dataset[col_name + '_ref'].isna() & full_dataset[col_name + '_data'].isna()
-            )
-            full_dataset[col_name + '_diff'] = (~(equals_cat)).astype(int)
+                xor_condition = (
+                    full_dataset[col_name + '_ref'].isna()
+                    & ~full_dataset[col_name + '_data'].isna()
+                ) | (
+                    ~full_dataset[col_name + '_ref'].isna()
+                    & full_dataset[col_name + '_data'].isna()
+                )
 
-        full_dataset.drop(columns=[col_name + '_ref', col_name + '_data'], inplace=True)
+                full_dataset.loc[xor_condition, col_name + '_diff'] = 1
 
-    full_dataset['diff'] = full_dataset.iloc[:, 2:].sum(axis=1) / len(cols_to_keep)
+                both_nan_condition = (
+                    full_dataset[col_name + '_ref'].isna() & full_dataset[col_name + '_data'].isna()
+                )
 
-    out = full_dataset[['index_data', 'diff']].groupby('index_data').min().reset_index(drop=True)
-    return out['diff']
+                full_dataset.loc[both_nan_condition, col_name + '_diff'] = 0
+
+            elif sdtype in ['categorical', 'boolean']:
+                equals_cat = (
+                    full_dataset[col_name + '_ref'] == full_dataset[col_name + '_data']
+                ) | (
+                    full_dataset[col_name + '_ref'].isna() & full_dataset[col_name + '_data'].isna()
+                )
+                full_dataset[col_name + '_diff'] = (~equals_cat).astype(int)
+
+            full_dataset.drop(columns=[col_name + '_ref', col_name + '_data'], inplace=True)
+
+        full_dataset['diff'] = full_dataset.iloc[:, 2:].sum(axis=1) / len(cols_to_keep)
+        chunk_result = (
+            full_dataset[['index_data', 'diff']].groupby('index_data').min().reset_index(drop=True)
+        )
+        results.append(chunk_result['diff'])
+
+    result = pd.concat(results, ignore_index=True)
+    result.name = None
+    return result

--- a/tests/integration/single_table/privacy/test_dcr_baseline_protection.py
+++ b/tests/integration/single_table/privacy/test_dcr_baseline_protection.py
@@ -159,6 +159,7 @@ class TestDCRBaselineProtection:
         )
 
         # Assert
+        print(result)
         assert result['median_DCR_to_real_data']['synthetic_data'] == 1.0
         assert result['median_DCR_to_real_data']['random_data_baseline'] == 0.0
         assert np.isnan(result['score'])
@@ -167,7 +168,7 @@ class TestDCRBaselineProtection:
         """Test end to end with a simple single synthetic value."""
         # Setup
         real_data = pd.DataFrame(data={'A': [2, 6, 3, 4, 1]})
-        synthetic_data = pd.DataFrame(data={'A': [5, 5, 5, 5, 5]})
+        synthetic_data = pd.DataFrame(data={'A': [5, 7, 5, 7, 5]})
         metadata = {'columns': {'A': {'sdtype': 'numerical'}}}
         num_rows_sample = 1
         num_iterations = 5

--- a/tests/integration/single_table/privacy/test_dcr_utils.py
+++ b/tests/integration/single_table/privacy/test_dcr_utils.py
@@ -20,7 +20,7 @@ def test_calculate_dcr():
     metadata = {'columns': {'num_col': {'sdtype': 'numerical'}}}
 
     # Run
-    result = calculate_dcr(real_data=real_df, synthetic_data=synthetic_df_diff, metadata=metadata)
+    result = calculate_dcr(reference_dataset=real_df, dataset=synthetic_df_diff, metadata=metadata)
 
     # Assert
     expected_result = pd.Series([0.2, 0.0])
@@ -49,7 +49,7 @@ def test_calculate_dcr_with_zero_col_range():
     metadata = {'columns': {'num_col': {'sdtype': 'numerical'}, 'date_col': {'sdtype': 'datetime'}}}
 
     # Run
-    result = calculate_dcr(real_data=real_df, synthetic_data=synthetic_df_diff, metadata=metadata)
+    result = calculate_dcr(reference_dataset=real_df, dataset=synthetic_df_diff, metadata=metadata)
 
     # Assert
     expected_result = pd.Series([1.0, 1.0, 1.0, 0.5, 0.0])

--- a/tests/unit/single_table/privacy/test_dcr_baseline_protection.py
+++ b/tests/unit/single_table/privacy/test_dcr_baseline_protection.py
@@ -56,7 +56,7 @@ class TestDCRBaselineProtection:
     @patch(
         'sdmetrics.single_table.privacy.dcr_baseline_protection.DCRBaselineProtection._generate_random_data'
     )
-    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr_optimized')
+    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr')
     def test_compute_breakdown(self, mock_calculate_dcr, mock_random_data, test_data):
         """Test that compute breakdown correctly measures the fraction of data overfitted."""
         # Setup
@@ -182,7 +182,7 @@ class TestDCRBaselineProtection:
         # Assert
         pd.testing.assert_frame_equal(random_data_1, random_data_2)
 
-    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr_optimized')
+    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr')
     def test_compute_breakdown_with_dcr_random_median_zero(self, mock_calculate_dcr, test_data):
         """Test compute_breakdown when random median dcr score is 0."""
         # Setup

--- a/tests/unit/single_table/privacy/test_dcr_baseline_protection.py
+++ b/tests/unit/single_table/privacy/test_dcr_baseline_protection.py
@@ -56,7 +56,7 @@ class TestDCRBaselineProtection:
     @patch(
         'sdmetrics.single_table.privacy.dcr_baseline_protection.DCRBaselineProtection._generate_random_data'
     )
-    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr')
+    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr_optimized')
     def test_compute_breakdown(self, mock_calculate_dcr, mock_random_data, test_data):
         """Test that compute breakdown correctly measures the fraction of data overfitted."""
         # Setup
@@ -182,7 +182,7 @@ class TestDCRBaselineProtection:
         # Assert
         pd.testing.assert_frame_equal(random_data_1, random_data_2)
 
-    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr')
+    @patch('sdmetrics.single_table.privacy.dcr_baseline_protection.calculate_dcr_optimized')
     def test_compute_breakdown_with_dcr_random_median_zero(self, mock_calculate_dcr, test_data):
         """Test compute_breakdown when random median dcr score is 0."""
         # Setup
@@ -199,6 +199,7 @@ class TestDCRBaselineProtection:
         )
 
         # Assert
+        print(result)
         assert result['median_DCR_to_real_data']['random_data_baseline'] == 0.0
         assert np.isnan(result['score'])
 

--- a/tests/unit/single_table/privacy/test_dcr_utils.py
+++ b/tests/unit/single_table/privacy/test_dcr_utils.py
@@ -5,11 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sdmetrics._utils_metadata import _convert_datetime_columns
 from sdmetrics.single_table.privacy.dcr_utils import (
-    _calculate_dcr_between_row_and_data,
-    _calculate_dcr_between_rows,
-    _calculate_dcr_value,
     calculate_dcr,
 )
 from tests.utils import check_if_value_in_threshold
@@ -160,117 +156,6 @@ SECONDS_IN_DAY = 86400
 ACCURACY_THRESHOLD = 0.000001
 
 
-@pytest.mark.parametrize(
-    'synthetic_value, real_value, col_range, sdtype, expected_dist',
-    [
-        (2.0, 2.0, 10.0, 'numerical', 0.0),
-        (1.0, 2.0, 10.0, 'numerical', 0.1),
-        (2.0, 1.0, 10.0, 'numerical', 0.1),
-        (100.0, 1.0, 10.0, 'numerical', 1.0),
-        (None, 1.0, 10.0, 'numerical', 1.0),
-        (1.0, np.nan, 10.0, 'numerical', 1.0),
-        (np.nan, None, 10.0, 'numerical', 0.0),
-        ('A', 'B', None, 'categorical', 1.0),
-        ('B', 'B', None, 'categorical', 0.0),
-        ('B', 'A', None, 'categorical', 1.0),
-        (None, 'B', None, 'categorical', 1.0),
-        ('A', None, None, 'categorical', 1.0),
-        (None, None, None, 'categorical', 0.0),
-        (0, None, None, 'categorical', 1.0),
-        (np.nan, None, None, 'categorical', 0.0),
-        (np.nan, np.nan, None, 'categorical', 0.0),
-        (True, False, None, 'boolean', 1.0),
-        (True, True, None, 'boolean', 0.0),
-        (False, True, None, 'boolean', 1.0),
-        (True, None, None, 'boolean', 1.0),
-        (datetime(2025, 1, 1).timestamp(), None, SECONDS_IN_DAY, 'datetime', 1.0),
-        (None, datetime(2025, 1, 1).timestamp(), SECONDS_IN_DAY, 'datetime', 1.0),
-        (
-            datetime(2025, 1, 1).timestamp(),
-            datetime(2025, 1, 1).timestamp(),
-            SECONDS_IN_DAY,
-            'datetime',
-            0.0,
-        ),
-        (
-            datetime(2025, 1, 2).timestamp(),
-            datetime(2025, 1, 1).timestamp(),
-            2 * SECONDS_IN_DAY,
-            'datetime',
-            0.5,
-        ),
-        (
-            datetime(2025, 10, 10).timestamp(),
-            datetime(2025, 1, 1).timestamp(),
-            SECONDS_IN_DAY,
-            'datetime',
-            1.0,
-        ),
-    ],
-)
-def test__calculate_dcr_value(synthetic_value, real_value, col_range, sdtype, expected_dist):
-    """Test _calculate_dcr_value with different types of values."""
-    # Run
-    dist = _calculate_dcr_value(synthetic_value, real_value, sdtype, col_range)
-
-    # Assert
-    assert dist == expected_dist
-
-
-def test__calculate_dcr_value_missing_range():
-    """Test _calculate_dcr_value with missing range for numerical values."""
-    # Setup
-    error_message = (
-        'No col_range was provided. The col_range is required '
-        'for numerical and datetime sdtype DCR calculation.'
-    )
-
-    # Assert
-    with pytest.raises(ValueError, match=error_message):
-        _calculate_dcr_value(1, 1, 'numerical', None)
-
-
-def test__calculate_dcr_between_rows(
-    real_data, synthetic_data, test_metadata, column_ranges, expected_row_comparisons
-):
-    """Test _calculate_dcr_between_rows for all row combinations"""
-    # Setup
-    result = []
-    real_data = _convert_datetime_columns(real_data, test_metadata)
-    synthetic_data = _convert_datetime_columns(synthetic_data, test_metadata)
-
-    # Run
-    for _, s_row_obj in synthetic_data.iterrows():
-        for _, t_row_obj in real_data.iterrows():
-            dist = _calculate_dcr_between_rows(s_row_obj, t_row_obj, column_ranges, test_metadata)
-            result.append(dist)
-
-    # Assert
-    for i in range(len(expected_row_comparisons)):
-        check_if_value_in_threshold(result[i], expected_row_comparisons[i], ACCURACY_THRESHOLD)
-
-
-def test__calculate_dcr_between_row_and_data(
-    real_data, synthetic_data, column_ranges, test_metadata, expected_dcr_result
-):
-    """Test _calculate_dcr_between_row_and_data for all rows."""
-    # Setup
-    result = []
-    real_data = _convert_datetime_columns(real_data, test_metadata)
-    synthetic_data = _convert_datetime_columns(synthetic_data, test_metadata)
-
-    # Run
-    for _, s_row_obj in synthetic_data.iterrows():
-        dist = _calculate_dcr_between_row_and_data(
-            s_row_obj, real_data, column_ranges, test_metadata
-        )
-        result.append(dist)
-
-    # Assert
-    for i in range(len(expected_dcr_result)):
-        check_if_value_in_threshold(result[i], expected_dcr_result[i], ACCURACY_THRESHOLD)
-
-
 def test_calculate_dcr(
     real_data,
     synthetic_data,
@@ -281,10 +166,10 @@ def test_calculate_dcr(
     """Calculate the DCR for all rows in a dataset against a traning dataset."""
     # Run
     result_dcr = calculate_dcr(
-        synthetic_data=synthetic_data, real_data=real_data, metadata=test_metadata
+        dataset=synthetic_data, reference_dataset=real_data, metadata=test_metadata
     )
     result_same_dcr = calculate_dcr(
-        synthetic_data=synthetic_data, real_data=synthetic_data, metadata=test_metadata
+        dataset=synthetic_data, reference_dataset=synthetic_data, metadata=test_metadata
     )
 
     # Assert
@@ -305,7 +190,7 @@ def test_calculate_dcr_different_cols_in_metadata(real_data, synthetic_data, tes
 
     # Run
     result = calculate_dcr(
-        synthetic_data=synthetic_data, real_data=real_data, metadata=test_metadata
+        dataset=synthetic_data, reference_dataset=real_data, metadata=test_metadata
     )
     expected_result = pd.Series([0.0, 0.1, 0.2, 0.02, 0.06, 0.0])
 
@@ -315,7 +200,7 @@ def test_calculate_dcr_different_cols_in_metadata(real_data, synthetic_data, tes
     test_metadata['columns'].pop('num_col')
     error_msg = 'There are no overlapping statistical columns to measure.'
     with pytest.raises(ValueError, match=error_msg):
-        calculate_dcr(synthetic_data=synthetic_data, real_data=real_data, metadata=test_metadata)
+        calculate_dcr(dataset=synthetic_data, reference_dataset=real_data, metadata=test_metadata)
 
 
 def test_calculate_dcr_with_shuffled_data():
@@ -333,9 +218,9 @@ def test_calculate_dcr_with_shuffled_data():
     metadata = {'columns': {'num_col': {'sdtype': 'numerical'}}}
 
     # Run
-    result = calculate_dcr(synthetic_data=synthetic_df, real_data=real_df, metadata=metadata)
+    result = calculate_dcr(dataset=synthetic_df, reference_dataset=real_df, metadata=metadata)
     result_shuffled = calculate_dcr(
-        synthetic_data=synthetic_df_shuffled, real_data=real_df_shuffled, metadata=metadata
+        dataset=synthetic_df_shuffled, reference_dataset=real_df_shuffled, metadata=metadata
     )
 
     # Assert
@@ -368,9 +253,9 @@ def test_calculate_dcr_with_zero_range():
     metadata = {'columns': {'num_col': {'sdtype': 'numerical'}, 'date_col': {'sdtype': 'datetime'}}}
 
     # Run and Assert
-    result = calculate_dcr(real_data=real_df, synthetic_data=synthetic_df_diff, metadata=metadata)
+    result = calculate_dcr(reference_dataset=real_df, dataset=synthetic_df_diff, metadata=metadata)
     assert result[0] == 1.0
-    result = calculate_dcr(real_data=real_df, synthetic_data=synthetic_df_same, metadata=metadata)
+    result = calculate_dcr(reference_dataset=real_df, dataset=synthetic_df_same, metadata=metadata)
     assert result[0] == 0.0
-    result = calculate_dcr(real_data=real_df, synthetic_data=synthetic_df_half, metadata=metadata)
+    result = calculate_dcr(reference_dataset=real_df, dataset=synthetic_df_half, metadata=metadata)
     assert result[0] == 0.5


### PR DESCRIPTION
In order to improve the speed of DCR calculations, we end up cross-merging the datasets (we do this piecemeal of 1000 rows) in order to run vectorized operations instead of running an `apply` to the dataframes.