### PR TITLE
Produce empty plot if all values are null for `get_column_plot`

### DIFF
--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -337,6 +337,7 @@ def _generate_column_plot(
             'y': 0.5,
             'showarrow': False,
             'text': 'No data to visualize',
+            'font': {'size': PlotConfig.FONT_SIZE * 2},
         })
 
     show_missing_values = missing_data_real > 0 or missing_data_synthetic > 0

--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -230,15 +230,13 @@ def _generate_column_distplot(real_data, synthetic_data, plot_kwargs={}):
     has_data = any(len(data) > 0 for data in hist_data)
 
     if has_data:
-        fig = ff.create_distplot(
+        return ff.create_distplot(
             hist_data,
             col_names,
             **{**default_distplot_kwargs, **plot_kwargs},
         )
-    else:
-        fig = go.Figure()
 
-    return fig
+    return go.Figure()
 
 
 def _generate_column_plot(
@@ -324,9 +322,9 @@ def _generate_column_plot(
 
     annotations = []
     if fig.data:
-        for i, name in enumerate(col_names):
+        for idx, name in enumerate(col_names):
             fig.update_traces(
-                x=pd.to_datetime(fig.data[i].x) if is_datetime_sdtype else fig.data[i].x,
+                x=pd.to_datetime(fig.data[idx].x) if is_datetime_sdtype else fig.data[idx].x,
                 hovertemplate=f'<b>{name}</b><br>Frequency: %{{y}}<extra></extra>',
                 selector={'name': name},
                 **trace_args,

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -1,6 +1,7 @@
 import re
 from unittest.mock import ANY, Mock, call, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -366,6 +367,28 @@ def test_get_column_plot_column_not_found():
     match = re.escape("Column 'start_date' not found in synthetic table data.")
     with pytest.raises(ValueError, match=match):
         get_column_plot(pd.DataFrame({'start_date': []}), synthetic_data, 'start_date')
+
+
+def test_get_column_plot_nan_data():
+    """Test the ``get_column_plot`` method when data is all nans."""
+    # Setup
+    real_data = pd.DataFrame({'values': [np.nan] * 5})
+    synthetic_data = pd.DataFrame({'values': [np.nan] * 5})
+
+    # Run
+    fig_bar = get_column_plot(real_data, synthetic_data, 'values', plot_type='bar')
+    fig_distplot = get_column_plot(real_data, synthetic_data, 'values', plot_type='distplot')
+
+    # Assert
+    annotation_bar = fig_bar.layout.annotations[0]
+    assert annotation_bar.text == 'No data to visualize'
+    assert annotation_bar.x == 0.5
+    assert annotation_bar.y == 0.5
+
+    annotation_distplot = fig_distplot.layout.annotations[0]
+    assert annotation_distplot.text == 'No data to visualize'
+    assert annotation_distplot.x == 0.5
+    assert annotation_distplot.y == 0.5
 
 
 def test_get_column_plot_bad_plot_type():


### PR DESCRIPTION
resolves #757 
CU-86b4e3whq

Handle when there is nan values only for both `distplot` and `bar` types.

Updated Font size
![Plot](https://github.com/user-attachments/assets/6f77a356-a9b1-46c8-b8d2-4e00c73c73ce)
