### PR TITLE
Replace `create_distplot` by manually plotting the kde curve

### DIFF
--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -240,8 +240,6 @@ def _generate_column_distplot(real_data, synthetic_data, plot_kwargs={}):
     Returns:
         plotly.graph_objects._figure.Figure
     """
-    plot_kwargs = plot_kwargs or {}
-
     hist_data = []
     col_names = []
     colors = []
@@ -265,7 +263,6 @@ def _generate_column_distplot(real_data, synthetic_data, plot_kwargs={}):
         end = max(data)
 
         curve_x = [start + x * (end - start) / 500 for x in range(500)]
-
         curve_y = scipy.stats.gaussian_kde(data)(curve_x)
 
         traces.append(

--- a/sdmetrics/visualization.py
+++ b/sdmetrics/visualization.py
@@ -5,9 +5,9 @@ from functools import wraps
 
 import pandas as pd
 import plotly.express as px
-import plotly.figure_factory as ff
 import plotly.graph_objects as go
 import plotly.io as pio
+import scipy
 from pandas.api.types import is_datetime64_dtype
 
 from sdmetrics.reports.utils import PlotConfig
@@ -240,6 +240,8 @@ def _generate_column_distplot(real_data, synthetic_data, plot_kwargs={}):
     Returns:
         plotly.graph_objects._figure.Figure
     """
+    plot_kwargs = plot_kwargs or {}
+
     hist_data = []
     col_names = []
     colors = []
@@ -252,22 +254,31 @@ def _generate_column_distplot(real_data, synthetic_data, plot_kwargs={}):
         col_names.append('Synthetic')
         colors.append(PlotConfig.DATACEBO_GREEN)
 
-    default_distplot_kwargs = {
-        'show_hist': False,
-        'show_rug': False,
-        'colors': colors,
-    }
-
     has_data = any(len(data) > 0 for data in hist_data)
 
-    if has_data:
-        return ff.create_distplot(
-            hist_data,
-            col_names,
-            **{**default_distplot_kwargs, **plot_kwargs},
+    if not has_data:
+        return go.Figure()
+
+    traces = []
+    for index, data in enumerate(hist_data):
+        start = min(data)
+        end = max(data)
+
+        curve_x = [start + x * (end - start) / 500 for x in range(500)]
+
+        curve_y = scipy.stats.gaussian_kde(data)(curve_x)
+
+        traces.append(
+            go.Scatter(
+                x=curve_x,
+                y=curve_y,
+                mode='lines',
+                name=col_names[index],
+                line={'color': colors[index]},
+            )
         )
 
-    return go.Figure()
+    return go.Figure(data=traces, **plot_kwargs)
 
 
 def _generate_column_plot(

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -162,8 +162,8 @@ def test_generate_cardinality_bar_plot(mock_px):
         )
 
 
-@patch('sdmetrics.visualization.ff')
-def test_generate_cardinality_distplot(mock_ff):
+@patch('sdmetrics.visualization.go.Figure')
+def test_generate_cardinality_distplot(mock_figure):
     """Test the ``_generate_cardinality_plot`` method with ``plot_type``=='distplot'."""
     # Setup
     mock_real_data = pd.Series([1, 1, 2, 2, 2], name='values')
@@ -173,8 +173,8 @@ def test_generate_cardinality_distplot(mock_ff):
     child_foreign_key = 'child_key'
 
     mock_fig = Mock()
-    mock_ff.create_distplot.return_value = mock_fig
     mock_fig.data = [Mock(), Mock()]
+    mock_figure.return_value = mock_fig
 
     # Run
     _generate_cardinality_plot(
@@ -185,15 +185,17 @@ def test_generate_cardinality_distplot(mock_ff):
         plot_type='distplot',
     )
 
-    # Expected call
-    expected_kwargs = {'show_hist': False, 'show_rug': False, 'colors': ['#000036', '#01E0C9']}
-
     # Assert
-    mock_ff.create_distplot.assert_called_once_with(
-        [SeriesMatcher(mock_real_data), SeriesMatcher(mock_synthetic_data)],
-        ['Real', 'Synthetic'],
-        **expected_kwargs,
-    )
+    mock_figure.assert_called_once()
+    real_trace, synthetic_trace = mock_figure.call_args[1]['data']
+
+    assert real_trace.name == 'Real'
+    assert real_trace.mode == 'lines'
+    assert real_trace.line.color == '#000036'
+
+    assert synthetic_trace.name == 'Synthetic'
+    assert synthetic_trace.mode == 'lines'
+    assert synthetic_trace.line.color == '#01E0C9'
 
     title = (
         f"Relationship (child foreign key='{child_foreign_key}' and parent "
@@ -465,30 +467,31 @@ def test__generate_column_bar_plot(mock_histogram):
     mock_histogram.assert_called_once_with(ANY, **expected_parameters)
 
 
-@patch('sdmetrics.visualization.ff.create_distplot')
-def test__generate_column_distplot(mock_distplot):
+@patch('sdmetrics.visualization.scipy.stats.gaussian_kde')
+def test__generate_column_distplot(mock_gaussian_kde):
     """Test ``_generate_column_distplot`` functionality"""
     # Setup
     real_data = pd.DataFrame({'values': [1, 2, 2, 3, 5]})
     synthetic_data = pd.DataFrame({'values': [2, 2, 3, 4, 5]})
 
+    real_kde = Mock(return_value=np.arange(500))
+    synthetic_kde = Mock(return_value=np.arange(500, 1000))
+    mock_gaussian_kde.side_effect = [real_kde, synthetic_kde]
+    plot_kwargs = {'layout': {'title': 'check plot kwargs are used'}}
+
     # Run
-    _generate_column_distplot(real_data, synthetic_data)
+    fig = _generate_column_distplot(real_data, synthetic_data, plot_kwargs)
 
     # Assert
-    expected_data = []
-    expected_data.append(real_data['values'])
-    expected_data.append(synthetic_data['values'])
-    expected_data == mock_distplot.call_args[0][0]
-    expected_col = ['Real', 'Synthetic']
-    expected_colors = [PlotConfig.DATACEBO_DARK, PlotConfig.DATACEBO_GREEN]
-    expected_parameters = {
-        'show_hist': False,
-        'show_rug': False,
-        'colors': expected_colors,
-    }
-    assert expected_parameters == mock_distplot.call_args[1]
-    mock_distplot.assert_called_once_with(expected_data, expected_col, **expected_parameters)
+    assert fig.layout.title.text == 'check plot kwargs are used'
+    assert len(fig.data) == 2
+    mock_gaussian_kde.assert_has_calls([
+        call(real_data['values']),
+        call(synthetic_data['values']),
+    ])
+
+    real_kde.assert_called_once()
+    synthetic_kde.assert_called_once()
 
 
 @patch('sdmetrics.visualization._generate_column_distplot')


### PR DESCRIPTION
Resolve #917

Based on plotly's recent [release](https://github.com/plotly/plotly.py/pull/5627), they recommend replaced `create_distplot` with `plotly.express.histogram`. However, the [histogram](https://plotly.com/python/histograms/) api does not support our usage of obtaining the distribution curve.

I resorted to manually compute the kde curve using the same logic outlined [here](https://github.com/plotly/plotly.py/blob/495134a8c74406a85660ae56178049017e0e3a41/plotly/figure_factory/_distplot.py#L342), then added them to the trace.

Example plot
<img width="1496" height="757" alt="newplot(19)" src="https://github.com/user-attachments/assets/084951e6-e5f1-467b-b5f3-bda098740233" />

